### PR TITLE
ignore storage failure when has multi-storages

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -200,7 +200,7 @@ func loadStoragesConfig(model *ModelConfig) {
 	// Backward compatible with `store_with` config
 	storeWith := model.Viper.Sub("store_with")
 	if storeWith != nil {
-		logger.Warn(`[Deprecated] "store_with" is deprecated now, please use "storages" which supports multiple storages. cycler config which usually located in "~/.gobackup/cycler" and named "MODEL.json" should be renamed to "MODEL_STORAGENAME.json", or cycler will start from scratch.`)
+		logger.Warn(`[Deprecated] "store_with" is deprecated now, please use "storages" which supports multiple storages. Cycler config which usually located in "~/.gobackup/cycler" and named "MODEL.json" should be renamed to "MODEL_STORAGENAME.json", or cycler will start from scratch.`)
 		storageConfigs["store_with"] = SubConfig{
 			Name:  "",
 			Type:  model.Viper.GetString("store_with.type"),

--- a/config/config.go
+++ b/config/config.go
@@ -200,7 +200,7 @@ func loadStoragesConfig(model *ModelConfig) {
 	// Backward compatible with `store_with` config
 	storeWith := model.Viper.Sub("store_with")
 	if storeWith != nil {
-		logger.Warn(`[Deprecated] "store_with" is deprecated now, please use "storages" which supports multiple storages.`)
+		logger.Warn(`[Deprecated] "store_with" is deprecated now, please use "storages" which supports multiple storages. cycler config which usually located in "~/.gobackup/cycler" and named "MODEL.json" should be renamed to "MODEL_STORAGENAME.json", or cycler will start from scratch.`)
 		storageConfigs["store_with"] = SubConfig{
 			Name:  "",
 			Type:  model.Viper.GetString("store_with.type"),

--- a/storage/base.go
+++ b/storage/base.go
@@ -133,11 +133,25 @@ func runModel(model config.ModelConfig, archivePath string, storageConfig config
 
 // Run storage
 func Run(model config.ModelConfig, archivePath string) (err error) {
+	logger := logger.Tag("Storage")
+	var hasSuccess bool
+	n := len(model.Storages)
 	for _, storageConfig := range model.Storages {
 		err := runModel(model, archivePath, storageConfig)
 		if err != nil {
-			return err
+			if n == 1 {
+				return err
+			} else {
+				logger.Error(err)
+				continue
+			}
+		} else {
+			hasSuccess = true
 		}
+	}
+
+	if !hasSuccess {
+		return fmt.Errorf("All storages are failed")
 	}
 
 	return nil


### PR DESCRIPTION
Currently in multiple storages scenario any storage failure would prevent other storages backup, it's better to leave it alone.

### After

```
2022/12/08 21:28:48 [Storage] => Storage | ftp
2022/12/08 21:28:48 [Storage] Sorry, cleartext sessions and weak ciphers are not accepted on this server.
Please reconnect using TLS security mechanisms.
2022/12/08 21:28:48 [Storage] => Storage | local
2022/12/08 21:28:48 [Local] Store succeeded /tmp/demo/2022.12.08.21.28.48.tar.xz
```