### PR TITLE
Fix #107: fix Cloudflare R2 endpoint

### DIFF
--- a/storage/s3.go
+++ b/storage/s3.go
@@ -89,7 +89,7 @@ func (s S3) defaultEndpoint() *string {
 	case "kodo":
 		return aws.String(fmt.Sprintf("s3-%s.qiniucs.com", s.viper.GetString("region")))
 	case "r2":
-		return aws.String(fmt.Sprintf("%s.r2.cloudflarestorage.com", s.viper.GetString("region")))
+		return aws.String(fmt.Sprintf("%s.r2.cloudflarestorage.com", s.viper.GetString("account_id")))
 	case "spaces":
 		return aws.String(fmt.Sprintf("%s.digitaloceanspaces.com", s.viper.GetString("region")))
 	}


### PR DESCRIPTION
```yaml
storages:
  r2:
    type: r2
    bucket: gobackup
    account_id: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
    path: backups/demo
    access_key_id: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
    secret_access_key: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
```

```
2022/12/11 18:28:56 [Config] Load config from default path.
2022/12/11 18:28:56 [Model: demo] WorkDir: /tmp/gobackup1241490941/1670812136690207811/demo
2022/12/11 18:28:56 [Database] => database | sqlite: sqlite
2022/12/11 18:28:56 [SQLite] -> Dumping SQLite...
2022/12/11 18:28:56 [SQLite] dump path: /tmp/gobackup1241490941/1670812136690207811/demo/sqlite/sqlite/sample.sql
2022/12/11 18:28:56 [Database] Dump succeeded
2022/12/11 18:28:56 [Database] => database | mongodb: mongodb
2022/12/11 18:28:56 [MongoDB]
2022/12/11 18:28:56 [MongoDB] dump path: /tmp/gobackup1241490941/1670812136690207811/demo/mongodb/mongodb
2022/12/11 18:28:56 [Database] Dump succeeded
2022/12/11 18:28:56 [Compressor] => Compress | xz
2022/12/11 18:28:56 [Compressor] -> /tmp/gobackup1241490941/1670812136690207811/2022.12.11.18.28.56.tar.xz
2022/12/11 18:28:56 [Storage] => Storage | r2
2022/12/11 18:28:56 [Cloudflare R2] -> Uploading (0 MiB)...
2022/12/11 18:28:57 [Cloudflare R2] => https://xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.r2.cloudflarestorage.com/gobackup/backups/demo/2022.12.11.18.28.56.tar.xz
2022/12/11 18:28:57 [Cloudflare R2] Duration 493 milliseconds 383 microseconds, rate 1.0 MiB/s
2022/12/11 18:28:57 [Model] Cleanup temp: /tmp/gobackup1241490941/
```