### PR TITLE
cleanup

### DIFF
--- a/archive/archive.go
+++ b/archive/archive.go
@@ -11,16 +11,16 @@ import (
 )
 
 // Run archive
-func Run(model config.ModelConfig) (err error) {
+func Run(model config.ModelConfig) error {
 	logger := logger.Tag("Archive")
 
 	if model.Archive == nil {
 		return nil
 	}
 
-	if err = helper.MkdirP(model.DumpPath); err != nil {
+	if err := helper.MkdirP(model.DumpPath); err != nil {
 		logger.Errorf("Failed to mkdir dump path %s: %v", model.DumpPath, err)
-		return
+		return err
 	}
 
 	includes := model.Archive.GetStringSlice("includes")
@@ -35,9 +35,9 @@ func Run(model config.ModelConfig) (err error) {
 	logger.Info("=> includes", len(includes), "rules")
 
 	opts := options(model.DumpPath, excludes, includes)
-	helper.Exec("tar", opts...)
 
-	return nil
+	_, err := helper.Exec("tar", opts...)
+	return err
 }
 
 func options(dumpPath string, excludes, includes []string) (opts []string) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -15,7 +15,9 @@ var (
 func init() {
 	os.Setenv("S3_ACCESS_KEY_ID", "xxxxxxxxxxxxxxxxxxxx")
 	os.Setenv("S3_SECRET_ACCESS_KEY", "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx")
-	Init(testConfigFile)
+	if err := Init(testConfigFile); err != nil {
+		panic(err.Error())
+	}
 }
 
 func TestModelsLength(t *testing.T) {
@@ -153,12 +155,14 @@ func TestInitWithNotExistsConfigFile(t *testing.T) {
 }
 
 func TestWatchConfigToReload(t *testing.T) {
-	Init(testConfigFile)
+	err := Init(testConfigFile)
+	assert.Nil(t, err)
+
 	lastUpdatedAt := UpdatedAt.UnixNano()
 	time.Sleep(1 * time.Millisecond)
 
 	// Touch `testConfigFile` to trigger file changes event
-	err := updateFile(testConfigFile)
+	err = updateFile(testConfigFile)
 	assert.Nil(t, err)
 
 	// Wait for reload

--- a/database/base_test.go
+++ b/database/base_test.go
@@ -9,7 +9,9 @@ import (
 )
 
 func init() {
-	config.Init("../gobackup_test.yml")
+	if err := config.Init("../gobackup_test.yml"); err != nil {
+		panic(err.Error())
+	}
 }
 
 type Monkey struct {

--- a/helper/exec.go
+++ b/helper/exec.go
@@ -13,7 +13,7 @@ import (
 )
 
 var (
-	spaceRegexp = regexp.MustCompile("[\\s]+")
+	spaceRegexp = regexp.MustCompile(`[\s]+`)
 )
 
 // Exec cli commands

--- a/helper/filepath_test.go
+++ b/helper/filepath_test.go
@@ -21,7 +21,7 @@ func TestMkdirP(t *testing.T) {
 	exist := IsExistsPath(dest)
 	assert.False(t, exist)
 
-	MkdirP(dest)
+	assert.Nil(t, MkdirP(dest))
 	defer os.Remove(dest)
 	exist = IsExistsPath(dest)
 	assert.True(t, exist)

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -12,7 +12,7 @@ import (
 
 type Logger struct {
 	logFlag int
-	myLog   log.Logger
+	myLog   *log.Logger
 }
 
 var (
@@ -35,7 +35,10 @@ func (w writer) Write(b []byte) (n int, err error) {
 
 func init() {
 	if isTest {
-		os.MkdirAll("../log", 0777)
+		if err := os.MkdirAll("../log", 0777); err != nil {
+			log.Printf("create log dir failed: %v\n", err)
+		}
+
 		logfile, _ := os.OpenFile("../log/test.log", os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
 		_myLog = log.New(logfile, "", _logFlag)
 	}
@@ -50,7 +53,7 @@ func SetLogger(logPath string) {
 }
 
 func newLogger() Logger {
-	return Logger{_logFlag, *_myLog}
+	return Logger{_logFlag, _myLog}
 }
 
 func Tag(tag string) Logger {

--- a/notifier/base.go
+++ b/notifier/base.go
@@ -38,7 +38,8 @@ func newNotifier(name string, config config.SubConfig) (Notifier, *Base, error) 
 
 	switch config.Type {
 	case "mail":
-		return NewMail(base), base, nil
+		mail, err := NewMail(base)
+		return mail, base, err
 	case "webhook":
 		return NewWebhook(base), base, nil
 	case "feishu":
@@ -66,7 +67,7 @@ func newNotifier(name string, config config.SubConfig) (Notifier, *Base, error) 
 	return nil, nil, fmt.Errorf("Notifier: %s is not supported", name)
 }
 
-func notify(model config.ModelConfig, title, message string, notifyType int) error {
+func notify(model config.ModelConfig, title, message string, notifyType int) {
 	logger := logger.Tag("Notifier")
 
 	logger.Infof("Running %d Notifiers", len(model.Notifiers))
@@ -91,19 +92,17 @@ func notify(model config.ModelConfig, title, message string, notifyType int) err
 			}
 		}
 	}
-
-	return nil
 }
 
-func Success(model config.ModelConfig) error {
+func Success(model config.ModelConfig) {
 	title := fmt.Sprintf("[GoBackup] OK: Backup %s has successfully", model.Name)
 	message := fmt.Sprintf("Backup of %s completed successfully at %s", model.Name, time.Now().Local())
-	return notify(model, title, message, notifyTypeSuccess)
+	notify(model, title, message, notifyTypeSuccess)
 }
 
-func Failure(model config.ModelConfig, reason string) error {
+func Failure(model config.ModelConfig, reason string) {
 	title := fmt.Sprintf("[GoBackup] Err: Backup %s has failed", model.Name)
 	message := fmt.Sprintf("Backup of %s failed at %s:\n\n%s", model.Name, time.Now().Local(), reason)
 
-	return notify(model, title, message, notifyTypeFailure)
+	notify(model, title, message, notifyTypeFailure)
 }

--- a/notifier/mail.go
+++ b/notifier/mail.go
@@ -6,8 +6,6 @@ import (
 	"net/smtp"
 	"sort"
 	"strings"
-
-	"github.com/gobackup/gobackup/logger"
 )
 
 type Mail struct {
@@ -20,29 +18,27 @@ type Mail struct {
 	port     string
 }
 
-func NewMail(base *Base) *Mail {
-	logger := logger.Tag("Notifier: mail")
-	mail := &Mail{}
-
+func NewMail(base *Base) (*Mail, error) {
 	base.viper.SetDefault("port", "25")
 
-	mail.username = base.viper.GetString("username")
-	mail.password = base.viper.GetString("password")
-
-	mail.to = strings.Split(base.viper.GetString("to"), ",")
-	if len(base.viper.GetString("username")) == 0 {
-		logger.Fatalf("username is required for mail notifier")
+	username := base.viper.GetString("username")
+	if len(username) == 0 {
+		return nil, fmt.Errorf("username is required for mail notifier")
 	}
 
-	mail.from = base.viper.GetString("from")
-	if len(mail.from) == 0 {
-		mail.from = mail.username
+	from := base.viper.GetString("from")
+	if len(from) == 0 {
+		from = username
 	}
 
-	mail.host = base.viper.GetString("host")
-	mail.port = base.viper.GetString("port")
-
-	return mail
+	return &Mail{
+		username: username,
+		password: base.viper.GetString("password"),
+		to:       strings.Split(base.viper.GetString("to"), ","),
+		from:     from,
+		host:     base.viper.GetString("host"),
+		port:     base.viper.GetString("port"),
+	}, nil
 }
 
 func (s Mail) getAddr() string {

--- a/notifier/mail_test.go
+++ b/notifier/mail_test.go
@@ -17,7 +17,8 @@ func Test_Mail(t *testing.T) {
 	base.viper.Set("password", "this-is-password")
 	base.viper.Set("host", "smtp.myhost.com")
 
-	mail := NewMail(&base)
+	mail, err := NewMail(&base)
+	assert.Nil(t, err)
 
 	assert.Equal(t, "user@myhost.com", mail.from)
 	assert.Equal(t, []string{"to@myhost.com", "to1@myhost.com"}, mail.to)
@@ -34,7 +35,9 @@ func Test_Mail(t *testing.T) {
 	base.viper.Set("from", "from@myhost.com")
 	base.viper.Set("port", "587")
 
-	mail = NewMail(&base)
+	mail, err = NewMail(&base)
+	assert.Nil(t, err)
+
 	assert.Equal(t, "from@myhost.com", mail.from)
 	assert.Equal(t, "587", mail.port)
 	assert.Equal(t, "smtp.myhost.com:587", mail.getAddr())

--- a/storage/azure.go
+++ b/storage/azure.go
@@ -37,7 +37,7 @@ type Azure struct {
 	client    *azblob.Client
 }
 
-func (s *Azure) open() (err error) {
+func (s *Azure) open() error {
 	s.viper.SetDefault("timeout", "300")
 	s.viper.SetDefault("container", "gobackup")
 	s.viper.SetDefault("path", "/")
@@ -57,7 +57,7 @@ func (s *Azure) open() (err error) {
 
 	credential, err := azidentity.NewClientSecretCredential(tenantId, clientId, clientSecret, nil)
 	if err != nil {
-		logger.Fatal("Invalid credentials with error: " + err.Error())
+		return fmt.Errorf("Invalid credentials with error: %w", err)
 	}
 
 	s.client, err = azblob.NewClient(s.getBucketURL(), credential, nil)
@@ -65,7 +65,7 @@ func (s *Azure) open() (err error) {
 		return err
 	}
 
-	return
+	return nil
 }
 
 func (s *Azure) close() {

--- a/storage/azure_test.go
+++ b/storage/azure_test.go
@@ -20,7 +20,7 @@ func Test_Azure_open(t *testing.T) {
 
 	viper.Set("bucket", "hello")
 
-	s.open()
+	assert.Nil(t, s.open())
 	assert.Equal(t, "https://hello.blob.core.windows.net", s.getBucketURL())
 	assert.Equal(t, "gobackup", s.container)
 	assert.Equal(t, "hello", s.account)
@@ -30,7 +30,7 @@ func Test_Azure_open(t *testing.T) {
 
 	viper.Set("container", "my-container")
 	viper.Set("account", "hello1")
-	s.open()
+	assert.Nil(t, s.open())
 	assert.Equal(t, "hello1", s.account)
 	assert.Equal(t, "https://hello1.blob.core.windows.net", s.getBucketURL())
 	assert.Equal(t, "my-container", s.container)

--- a/storage/cycler.go
+++ b/storage/cycler.go
@@ -2,7 +2,7 @@ package storage
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -94,13 +94,13 @@ func (c *Cycler) load(cyclerFileName string) {
 
 	// write example JSON if not exist
 	if !helper.IsExistsPath(cyclerFileName) {
-		if err := ioutil.WriteFile(cyclerFileName, []byte("[]"), 0660); err != nil {
+		if err := os.WriteFile(cyclerFileName, []byte("[]"), 0660); err != nil {
 			logger.Errorf("Failed to write file %s: %v", cyclerFileName, err)
 			return
 		}
 	}
 
-	f, err := ioutil.ReadFile(cyclerFileName)
+	f, err := os.ReadFile(cyclerFileName)
 	if err != nil {
 		logger.Error("Load cycler.json failed:", err)
 		return
@@ -126,7 +126,7 @@ func (c *Cycler) save(cyclerFileName string) {
 		return
 	}
 
-	err = ioutil.WriteFile(cyclerFileName, data, 0660)
+	err = os.WriteFile(cyclerFileName, data, 0660)
 	if err != nil {
 		logger.Error("Save cycler.json failed: ", err)
 		return

--- a/storage/ftp.go
+++ b/storage/ftp.go
@@ -93,7 +93,9 @@ func (s *FTP) open() error {
 }
 
 func (s *FTP) close() {
-	s.client.Quit()
+	if err := s.client.Quit(); err != nil {
+		logger.Errorf("FTP close error: %v", err.Error())
+	}
 }
 
 func (s *FTP) mkdir(rpath string) error {

--- a/storage/local.go
+++ b/storage/local.go
@@ -37,7 +37,9 @@ func (s *Local) upload(fileKey string) (err error) {
 
 	targetPath := path.Join(s.path, fileKey)
 	targetDir := path.Dir(targetPath)
-	helper.MkdirP(targetDir)
+	if err := helper.MkdirP(targetDir); err != nil {
+		logger.Errorf("failed to mkdir %q, %v", targetDir, err)
+	}
 
 	_, err = helper.Exec("cp", "-a", s.archivePath, targetPath)
 	if err != nil {

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -285,7 +285,7 @@ func (s *S3) upload(fileKey string) (err error) {
 			// set the part size as low as possible to avoid timeouts and aborts
 			// also set concurrency to 1 for the same reason
 			var partSize int64 = 64 * 1024 * 1024 // 64MiB
-			maxParts := math.Ceil(float64(progress.FileLength / partSize))
+			maxParts := progress.FileLength / partSize
 
 			// 10000 parts is the limit for AWS S3. If the resulting number of parts would exceed that limit, increase the
 			// part size as much as needed but as little possible

--- a/web/api.go
+++ b/web/api.go
@@ -128,7 +128,9 @@ func perform(c *gin.Context) {
 	}
 
 	var param performParam
-	c.Bind(&param)
+	if err := c.Bind(&param); err != nil {
+		logger.Errorf("Bind error: %v", err)
+	}
 
 	m := model.GetModelByName(param.Model)
 	if m == nil {
@@ -136,7 +138,11 @@ func perform(c *gin.Context) {
 		return
 	}
 
-	go m.Perform()
+	go func() {
+		if err := m.Perform(); err != nil {
+			logger.Errorf("Perform error: %v", err)
+		}
+	}()
 	c.JSON(200, gin.H{"message": fmt.Sprintf("Backup: %s performed in background.", param.Model)})
 }
 
@@ -203,7 +209,9 @@ func log(c *gin.Context) {
 				println(msg)
 			}
 
-			c.Writer.WriteString(msg + "\n")
+			if _, err := c.Writer.WriteString(msg + "\n"); err != nil {
+				logger.Errorf("Failed to write to stream: %v", err)
+			}
 			c.Writer.Flush()
 			return true
 		}
@@ -215,7 +223,9 @@ func tailFile() chan string {
 	out_chan := make(chan string)
 
 	file := fls.LineFile(logFile)
-	file.SeekLine(-50, io.SeekEnd)
+	if _, err := file.SeekLine(-50, io.SeekEnd); err != nil {
+		logger.Errorf("Failed to seek log file: %v", err)
+	}
 	bf := bufio.NewReader(file)
 
 	go func() {

--- a/web/api_test.go
+++ b/web/api_test.go
@@ -13,7 +13,9 @@ import (
 )
 
 func init() {
-	config.Init("../gobackup_test.yml")
+	if err := config.Init("../gobackup_test.yml"); err != nil {
+		panic(err.Error())
+	}
 }
 
 func assertMatchJSON(t *testing.T, expected map[string]any, actual string) {


### PR DESCRIPTION
- change `path` to `filepath`
- handle errors from all functions returning `error`
- remove `logger.Fatal` everywhere, except `main` (the only `Fatal`), and in tests `init` functions, change to panic there to trace error instead of failing tests with `ExitCode: 1`
- some style/staticcheck fixes