### PR TITLE
feat: support influxdb v2 through influx cli

### DIFF
--- a/database/base.go
+++ b/database/base.go
@@ -94,6 +94,8 @@ func runModel(model config.ModelConfig, dbConfig config.SubConfig) (err error) {
 		db = &SQLite{Base: base}
 	case "mssql":
 		db = &MSSQL{Base: base}
+	case "influxdb2":
+		db = &InfluxDB2{Base: base}
 	default:
 		logger.Warn(fmt.Errorf("model: %s databases.%s config `type: %s`, but is not implement", model.Name, dbConfig.Name, dbConfig.Type))
 		return

--- a/database/influxdb2.go
+++ b/database/influxdb2.go
@@ -23,17 +23,17 @@ type InfluxDB2 struct {
 
 func (db *InfluxDB2) init() (err error) {
 	viper := db.viper
-	viper.SetDefault("skipVerify", false)
-	viper.SetDefault("httpDebug", false)
+	viper.SetDefault("skip_verify", false)
+	viper.SetDefault("http_debug", false)
 
 	db.host = viper.GetString("host")
 	db.token = viper.GetString("token")
 	db.bucket = viper.GetString("bucket")
-	db.bucketId = viper.GetString("bucketId")
+	db.bucketId = viper.GetString("bucket_id")
 	db.org = viper.GetString("org")
-	db.orgId = viper.GetString("orgId")
-	db.skipVerify = viper.GetBool("skipVerify")
-	db.httpDebug = viper.GetBool("httpDebug")
+	db.orgId = viper.GetString("org_id")
+	db.skipVerify = viper.GetBool("skip_verify")
+	db.httpDebug = viper.GetBool("http_debug")
 
 	if db.host == "" {
 		return fmt.Errorf("no host specified in influxdb2 configuration '%s'", db.name)

--- a/database/influxdb2.go
+++ b/database/influxdb2.go
@@ -2,7 +2,6 @@ package database
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/gobackup/gobackup/helper"
 	"github.com/gobackup/gobackup/logger"
@@ -46,38 +45,38 @@ func (db *InfluxDB2) init() (err error) {
 	return nil
 }
 
-func (db *InfluxDB2) build() string {
-	opts := make([]string, 0, 15)
-	opts = append(opts, "influx backup")
-	opts = append(opts, "--host="+db.host+"")
-	opts = append(opts, "--token="+db.token+"")
+func (db *InfluxDB2) influxCliArguments() []string {
+	args := make([]string, 0, 15)
+	args = append(args, "backup")
+	args = append(args, "--host="+db.host+"")
+	args = append(args, "--token="+db.token+"")
 	if db.bucket != "" {
-		opts = append(opts, "--bucket="+db.bucket+"")
+		args = append(args, "--bucket="+db.bucket+"")
 	}
 	if db.bucketId != "" {
-		opts = append(opts, "--bucket-id="+db.bucketId+"")
+		args = append(args, "--bucket-id="+db.bucketId+"")
 	}
 	if db.org != "" {
-		opts = append(opts, "--org="+db.org+"")
+		args = append(args, "--org="+db.org+"")
 	}
 	if db.orgId != "" {
-		opts = append(opts, "--org-id="+db.orgId+"")
+		args = append(args, "--org-id="+db.orgId+"")
 	}
 	if db.skipVerify {
-		opts = append(opts, "--skip-verify")
+		args = append(args, "--skip-verify")
 	}
 	if db.httpDebug {
-		opts = append(opts, "--http-debug")
+		args = append(args, "--http-debug")
 	}
-	opts = append(opts, db.dumpPath)
-	return strings.Join(opts, " ")
+	args = append(args, db.dumpPath)
+	return args
 }
 
 func (db *InfluxDB2) perform() error {
 	logger := logger.Tag("InfluxDB2")
 
-	command := db.build()
-	out, err := helper.Exec(command)
+	args := db.influxCliArguments()
+	out, err := helper.Exec("influx", args...)
 	if err != nil {
 		return fmt.Errorf("-> Dump error: %s", err)
 	}

--- a/database/influxdb2.go
+++ b/database/influxdb2.go
@@ -1,0 +1,96 @@
+package database
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/gobackup/gobackup/helper"
+	"github.com/gobackup/gobackup/logger"
+)
+
+// MongoDB database
+//
+// type: mongodb
+// host: 127.0.0.1
+// port: 27017
+// database:
+// username:
+// password:
+// authdb:
+// exclude_tables:
+// oplog: false
+// args:
+type InfluxDB2 struct {
+	Base
+	host       string
+	token      string
+	bucket     string
+	bucketId   string
+	org        string
+	orgId      string
+	skipVerify bool
+	httpDebug  bool
+}
+
+func (db *InfluxDB2) init() (err error) {
+	viper := db.viper
+	viper.SetDefault("skipVerify", false)
+	viper.SetDefault("httpDebug", false)
+
+	db.host = viper.GetString("host")
+	db.token = viper.GetString("token")
+	db.bucket = viper.GetString("bucket")
+	db.bucketId = viper.GetString("bucketId")
+	db.org = viper.GetString("org")
+	db.orgId = viper.GetString("orgId")
+	db.skipVerify = viper.GetBool("skipVerify")
+
+	if db.host == "" {
+		return fmt.Errorf("no host specified in influxdb2 configuration: %s", db.name)
+	}
+	if db.token == "" {
+		return fmt.Errorf("no token specified in influxdb2 configuration: %s", db.name)
+	}
+
+	return nil
+}
+
+func (db *InfluxDB2) build() string {
+	opts := make([]string, 0, 15)
+	opts = append(opts, "influx backup")
+	opts = append(opts, "--host="+db.host+"")
+	opts = append(opts, "--token="+db.token+"")
+	if db.bucket != "" {
+		opts = append(opts, "--bucket="+db.bucket+"")
+	}
+	if db.bucketId != "" {
+		opts = append(opts, "--bucket-id="+db.bucketId+"")
+	}
+	if db.org != "" {
+		opts = append(opts, "--org="+db.org+"")
+	}
+	if db.orgId != "" {
+		opts = append(opts, "--org-id="+db.orgId+"")
+	}
+	if db.skipVerify {
+		opts = append(opts, "--skip-verify")
+	}
+	if db.httpDebug {
+		opts = append(opts, "--http-debug")
+	}
+	opts = append(opts, db.dumpPath)
+	return strings.Join(opts, " ")
+}
+
+func (db *InfluxDB2) perform() error {
+	logger := logger.Tag("InfluxDB2")
+
+	command := db.build()
+	out, err := helper.Exec(command)
+	if err != nil {
+		return fmt.Errorf("-> Dump error: %s", err)
+	}
+	logger.Info(out)
+	logger.Info("dump path:", db.dumpPath)
+	return nil
+}

--- a/database/influxdb2.go
+++ b/database/influxdb2.go
@@ -8,18 +8,8 @@ import (
 	"github.com/gobackup/gobackup/logger"
 )
 
-// MongoDB database
-//
-// type: mongodb
-// host: 127.0.0.1
-// port: 27017
-// database:
-// username:
-// password:
-// authdb:
-// exclude_tables:
-// oplog: false
-// args:
+// InfluxDB v2 database through `influx` cli
+// See https://docs.influxdata.com/influxdb/v2/reference/cli/influx/backup/
 type InfluxDB2 struct {
 	Base
 	host       string
@@ -44,12 +34,13 @@ func (db *InfluxDB2) init() (err error) {
 	db.org = viper.GetString("org")
 	db.orgId = viper.GetString("orgId")
 	db.skipVerify = viper.GetBool("skipVerify")
+	db.httpDebug = viper.GetBool("httpDebug")
 
 	if db.host == "" {
-		return fmt.Errorf("no host specified in influxdb2 configuration: %s", db.name)
+		return fmt.Errorf("no host specified in influxdb2 configuration '%s'", db.name)
 	}
 	if db.token == "" {
-		return fmt.Errorf("no token specified in influxdb2 configuration: %s", db.name)
+		return fmt.Errorf("no token specified in influxdb2 configuration '%s'", db.name)
 	}
 
 	return nil

--- a/database/influxdb2_test.go
+++ b/database/influxdb2_test.go
@@ -1,0 +1,70 @@
+package database
+
+import (
+	"testing"
+
+	"github.com/gobackup/gobackup/config"
+	"github.com/longbridgeapp/assert"
+	"github.com/spf13/viper"
+)
+
+func TestInfluxDB2_init(t *testing.T) {
+	createSubject := func(params map[string]interface{}) *InfluxDB2 {
+		viper := viper.New()
+		for key, value := range params {
+			viper.Set(key, value)
+		}
+		base := newBase(
+			config.ModelConfig{
+				DumpPath: "/data/backups",
+			},
+			// Creating a new base object.
+			config.SubConfig{
+				Type:  "influxdb2",
+				Name:  "influxdb-v2-oss",
+				Viper: viper,
+			},
+		)
+
+		return &InfluxDB2{
+			Base: base,
+		}
+	}
+
+	err1 := createSubject(map[string]interface{}{}).init()
+	assert.EqualError(t, err1, "no host specified in influxdb2 configuration 'influxdb-v2-oss'")
+	err2 := createSubject(map[string]interface{}{"host": "http://localhost:8086"}).init()
+	assert.EqualError(t, err2, "no token specified in influxdb2 configuration 'influxdb-v2-oss'")
+}
+
+func TestInfluxDB2_build(t *testing.T) {
+	viper := viper.New()
+	viper.Set("host", "http://localhost:8086")
+	viper.Set("token", "my-token")
+	viper.Set("org", "my-org")
+	viper.Set("orgId", "my-org-id")
+	viper.Set("bucket", "my-bucket")
+	viper.Set("bucketId", "my-bucket-id")
+	viper.Set("httpDebug", true)
+	viper.Set("skipVerify", true)
+
+	base := newBase(
+		config.ModelConfig{
+			DumpPath: "/data/backups",
+		},
+		// Creating a new base object.
+		config.SubConfig{
+			Type:  "influxdb2",
+			Name:  "influxdb-v2-oss",
+			Viper: viper,
+		},
+	)
+
+	db := &InfluxDB2{
+		Base: base,
+	}
+
+	err := db.init()
+	assert.NoError(t, err)
+	assert.Equal(t, db.build(), "influx backup --host=http://localhost:8086 --token=my-token --bucket=my-bucket --bucket-id=my-bucket-id --org=my-org --org-id=my-org-id --skip-verify --http-debug /data/backups/influxdb2/influxdb-v2-oss")
+}

--- a/database/influxdb2_test.go
+++ b/database/influxdb2_test.go
@@ -37,7 +37,7 @@ func TestInfluxDB2_init(t *testing.T) {
 	assert.EqualError(t, err2, "no token specified in influxdb2 configuration 'influxdb-v2-oss'")
 }
 
-func TestInfluxDB2_build(t *testing.T) {
+func TestInfluxDB2_influxCliArguments(t *testing.T) {
 	viper := viper.New()
 	viper.Set("host", "http://localhost:8086")
 	viper.Set("token", "my-token")
@@ -66,5 +66,7 @@ func TestInfluxDB2_build(t *testing.T) {
 
 	err := db.init()
 	assert.NoError(t, err)
-	assert.Equal(t, db.build(), "influx backup --host=http://localhost:8086 --token=my-token --bucket=my-bucket --bucket-id=my-bucket-id --org=my-org --org-id=my-org-id --skip-verify --http-debug /data/backups/influxdb2/influxdb-v2-oss")
+	assert.Equal(t, db.influxCliArguments(), []string{"backup",
+		"--host=http://localhost:8086", "--token=my-token", "--bucket=my-bucket", "--bucket-id=my-bucket-id",
+		"--org=my-org", "--org-id=my-org-id", "--skip-verify", "--http-debug", "/data/backups/influxdb2/influxdb-v2-oss"})
 }

--- a/database/influxdb2_test.go
+++ b/database/influxdb2_test.go
@@ -42,11 +42,11 @@ func TestInfluxDB2_influxCliArguments(t *testing.T) {
 	viper.Set("host", "http://localhost:8086")
 	viper.Set("token", "my-token")
 	viper.Set("org", "my-org")
-	viper.Set("orgId", "my-org-id")
+	viper.Set("org_id", "my-org-id")
 	viper.Set("bucket", "my-bucket")
-	viper.Set("bucketId", "my-bucket-id")
-	viper.Set("httpDebug", true)
-	viper.Set("skipVerify", true)
+	viper.Set("bucket_id", "my-bucket-id")
+	viper.Set("http_debug", true)
+	viper.Set("skip_verify", true)
 
 	base := newBase(
 		config.ModelConfig{


### PR DESCRIPTION
This PR adds support for InfluxDB v2 OSS as a source database.

It is required to have [influx cli](https://docs.influxdata.com/influxdb/v2/reference/cli/influx/?t=Linux) installed and in the PATH, at least for the `gobackup` tool.

An example configuration with influxdb v2 database backup:
```yaml
# gobackup config example
# -----------------------
# Put this file in follow place:
# ~/.gobackup/gobackup.yml or /etc/gobackup/gobackup.yml
# or run the gobackup tool with --config option pointing to this file
web:
  username: gobackup
  password: 123456
models:
  influxdb2_backup:
    description: "Perform local influxdb v2 backup"
    schedule:
      # At 04:05 on Sunday.
      cron: "5 4 * * sun"
    compress_with:
      type: tgz
    default_storage: local
    storages:
      local:
        type: local
        keep: 10
        path: /tmp/gobackup
    databases:
      influxdbv2-oss:
        type: influxdb2
        host: http://localhost:8086
        token: my-token

```

`type`, `token` and `host` properties are required
- `type` must be `influxdb2` 
- `host` (string) - HTTP address of InfluxDB
- `token` (string) - InfluxDB v2 API token
all other properties of `influxdb2` database are optional:
-  `bucket` (string) - name of the bucket to back up from
-  `bucket_id` (string) - ID of the bucket to back up from
-  `org`(string) - organization name
-  `org_id` (string) - organization ID
- `skip_verify` (boolean) - whether to skip TLS certificate verification
- `http_debug` (boolean) - whether to inspect communication with InfluxDB server

See also https://docs.influxdata.com/influxdb/v2/reference/cli/influx/backup/