### PR TITLE
Cleanup generated files after each step

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -63,6 +63,11 @@ func (m Model) Perform() (err error) {
 		return
 	}
 
+	logger.Infof("Cleanup WorkDir: %s/", m.Config.DumpPath)
+	if err := os.RemoveAll(m.Config.DumpPath); err != nil {
+		logger.Errorf("Cleanup temp dir %s error: %v", m.Config.DumpPath, err)
+	}
+
 	archivePath, err = encryptor.Run(archivePath, m.Config)
 	if err != nil {
 		return


### PR DESCRIPTION
# Problem

It's related to #208
Model's dump directory after making compressed file is no longer needed and that space can be used in next steps.
This also apply to compressed file after encryption and encrypted file after splitting.

# Solution

1. Delete model's dump directory after making compressed file
2. Delete compressed file after encryption (if encryption was enabled)
3. Delete encrypted file after splitting (if split was enabled)

