### PR TITLE
add mariadbackup to database list

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apk add \
   postgresql-client \
   mariadb-connector-c \
   mysql-client \
+  mariadb-backup \
   redis \
   mongodb-tools \
   sqlite \

--- a/database/base.go
+++ b/database/base.go
@@ -84,6 +84,8 @@ func runModel(model config.ModelConfig, dbConfig config.SubConfig) (err error) {
 	switch dbConfig.Type {
 	case "mysql":
 		db = &MySQL{Base: base}
+	case "mariadb":
+		db = &MariaDB{Base: base}
 	case "redis":
 		db = &Redis{Base: base}
 	case "postgresql":

--- a/database/mariadb.go
+++ b/database/mariadb.go
@@ -1,0 +1,121 @@
+package database
+
+import (
+	"fmt"
+	"strings"
+	"os"
+	"path"
+
+	"github.com/gobackup/gobackup/helper"
+	"github.com/gobackup/gobackup/logger"
+)
+
+// Mariadb database
+//
+// type: mariadb
+// host: 127.0.0.1
+// port: 3306
+// socket:
+// databases:
+// username: root
+// password:
+// args:
+
+type MariaDB struct {
+	Base
+	host          		string
+	port          		string
+	socket        		string
+	databases     		[]string
+	username      		string
+	password      		string
+	args          		string
+}
+
+func (db *MariaDB) init() (err error) {
+	viper := db.viper
+	viper.SetDefault("host", "127.0.0.1")
+	viper.SetDefault("username", "root")
+	viper.SetDefault("port", 3306)
+
+	db.host = viper.GetString("host")
+	db.port = viper.GetString("port")
+	db.socket = viper.GetString("socket")
+	db.databases = viper.GetStringSlice("databases")
+	db.username = viper.GetString("username")
+	db.password = viper.GetString("password")
+
+	if len(viper.GetString("args")) > 0 {
+		db.args = viper.GetString("args")
+	}
+
+	// socket
+	if len(db.socket) != 0 {
+		db.host = ""
+		db.port = ""
+	}
+
+	return nil
+}
+
+func createdatabasesfile(databasesfile string, databases []string) error {
+	file, err := os.Create(databasesfile)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	for _, database := range databases {
+		_, err := file.WriteString(database + "\n")
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (db *MariaDB) build() string {
+	dumpArgs := []string{}
+	if len(db.host) > 0 {
+		dumpArgs = append(dumpArgs, "--host", db.host)
+	}
+	if len(db.port) > 0 {
+		dumpArgs = append(dumpArgs, "--port", db.port)
+	}
+	if len(db.socket) > 0 {
+		dumpArgs = append(dumpArgs, "--socket", db.socket)
+	}
+	if len(db.username) > 0 {
+		dumpArgs = append(dumpArgs, "-u", db.username)
+	}
+	if len(db.password) > 0 {
+		dumpArgs = append(dumpArgs, `-p`+db.password)
+	}
+
+	if len(db.databases) > 0 {
+		databasesfile := path.Join(db.dumpPath, "databases-file.txt")
+		err := createdatabasesfile(databasesfile, db.databases)
+		if err != nil {
+			return fmt.Errorf("-> Dump error: %s", err)
+		}
+		dumpArgs = append(dumpArgs, "--databases-file=" + databasesfile)
+	}
+
+	if len(db.args) > 0 {
+		dumpArgs = append(dumpArgs, db.args)
+	}
+
+	dumpArgs = append(dumpArgs, "--target-dir="+db.dumpPath)
+	return "mariadb-backup --backup" + " " + strings.Join(dumpArgs, " ")
+}
+
+func (db *MariaDB) perform() error {
+	logger := logger.Tag("MariaDB")
+
+	logger.Info("-> Dumping MariaDB...")
+	_, err := helper.Exec(db.build())
+	if err != nil {
+		return fmt.Errorf("-> Dump error: %s", err)
+	}
+	logger.Info("dump path:", db.dumpPath)
+	return nil
+}

--- a/database/mariadb.go
+++ b/database/mariadb.go
@@ -95,7 +95,7 @@ func (db *MariaDB) build() string {
 		databasesfile := path.Join(db.dumpPath, "databases-file.txt")
 		err := createdatabasesfile(databasesfile, db.databases)
 		if err != nil {
-			logger.Error("-> Dump error: %s", err)
+			logger.Error("-> Dump error: ", err)
 		}
 		dumpArgs = append(dumpArgs, "--databases-file=" + databasesfile)
 	}

--- a/database/mariadb.go
+++ b/database/mariadb.go
@@ -95,7 +95,7 @@ func (db *MariaDB) build() string {
 		databasesfile := path.Join(db.dumpPath, "databases-file.txt")
 		err := createdatabasesfile(databasesfile, db.databases)
 		if err != nil {
-			return fmt.Errorf("-> Dump error: %s", err)
+			logger.Error("-> Dump error: %s", err)
 		}
 		dumpArgs = append(dumpArgs, "--databases-file=" + databasesfile)
 	}

--- a/database/mariadb.go
+++ b/database/mariadb.go
@@ -53,10 +53,6 @@ func (db *MariaDB) init() (err error) {
 		db.port = ""
 	}
 
-	if len(db.database) == 0 {
-		return fmt.Errorf("mariadb database config is required")
-	}
-
 	return nil
 }
 
@@ -81,7 +77,9 @@ func (db *MariaDB) build() string {
 	if len(db.args) > 0 {
 		dumpArgs = append(dumpArgs, db.args)
 	}
-	dumpArgs = append(dumpArgs, "--databases="+db.database)
+	if len(db.database) > 0 {
+		dumpArgs = append(dumpArgs, "--databases="+db.database)
+	}
 	dumpArgs = append(dumpArgs, "--target-dir="+db.dumpPath)
 
 	return "mariadb-backup --backup " + strings.Join(dumpArgs, " ")

--- a/database/mariadb_test.go
+++ b/database/mariadb_test.go
@@ -8,16 +8,13 @@ import (
 	"testing"
 
 	"github.com/longbridgeapp/assert"
-	"io/ioutil"
-	"path"
-	"strings"
 )
 
 func TestMariaDB_init(t *testing.T) {
 	viper := viper.New()
 	viper.Set("host", "1.2.3.4")
 	viper.Set("port", "1234")
-	viper.Set("databases", []string{"foo", "bar"})
+	viper.Set("database", "my_db")
 	viper.Set("username", "user1")
 	viper.Set("password", "pass1")
 	viper.Set("args", "--a1 --a2 --a3")
@@ -41,7 +38,7 @@ func TestMariaDB_init(t *testing.T) {
 	err := db.init()
 	assert.NoError(t, err)
 	script := db.build()
-	assert.Equal(t, script, "mariadb-backup --backup --host 1.2.3.4 --port 1234 -u user1 -ppass1 --databases-file=/data/backups/mariadb/mariadb1/databases-file.txt --a1 --a2 --a3 --target-dir=/data/backups/mariadb/mariadb1")
+	assert.Equal(t, script, "mariadb-backup --backup --host 1.2.3.4 --port 1234 -u user1 -ppass1 --a1 --a2 --a3 --databases=my_db --target-dir=/data/backups/mariadb/mariadb1")
 }
 
 func TestMariaDB_dumpArgsWithAdditionalOptions(t *testing.T) {
@@ -59,32 +56,9 @@ func TestMariaDB_dumpArgsWithAdditionalOptions(t *testing.T) {
 		host:     "127.0.0.2",
 		port:     "6378",
 		password: "*&^92'",
+		database: "my_db2",
 		args:     "--datadir=/var/lib64/mysql",
 	}
 
-	assert.Equal(t, db.build(), "mariadb-backup --backup --host 127.0.0.2 --port 6378 -p*&^92' --datadir=/var/lib64/mysql --target-dir=/data/backups/mariadb/mariadb1")
-}
-
-func TestMariaDB_databasesfileContent(t *testing.T) {
-	base := newBase(
-		config.ModelConfig{
-			DumpPath: "/data/backups/",
-		},
-		config.SubConfig{
-			Type: "mariadb",
-			Name: "mariadb1",
-		},
-	)
-	db := &MariaDB{
-		Base:     base,
-		databases: []string{"foo", "bar"},
-	}
-	databasesfile := path.Join(db.dumpPath, "databases-file.txt")
-	content, err := ioutil.ReadFile(databasesfile)
-	assert.NoError(t, err)
-
-	fileContent := string(content)
-	actualList := strings.Split(strings.TrimSpace(fileContent), "\n")
-	assert.Equal(t, len(db.databases), len(actualList))
-	assert.Equal(t, db.databases, actualList)
+	assert.Equal(t, db.build(), "mariadb-backup --backup --host 127.0.0.2 --port 6378 -p*&^92' --datadir=/var/lib64/mysql --databases=my_db2 --target-dir=/data/backups/mariadb/mariadb1")
 }

--- a/database/mariadb_test.go
+++ b/database/mariadb_test.go
@@ -1,0 +1,90 @@
+package database
+
+import (
+	"github.com/gobackup/gobackup/config"
+	"github.com/spf13/viper"
+
+	// "github.com/spf13/viper"
+	"testing"
+
+	"github.com/longbridgeapp/assert"
+	"io/ioutil"
+	"path"
+	"strings"
+)
+
+func TestMariaDB_init(t *testing.T) {
+	viper := viper.New()
+	viper.Set("host", "1.2.3.4")
+	viper.Set("port", "1234")
+	viper.Set("databases", []string{"foo", "bar"})
+	viper.Set("username", "user1")
+	viper.Set("password", "pass1")
+	viper.Set("args", "--a1 --a2 --a3")
+
+	base := newBase(
+		config.ModelConfig{
+			DumpPath: "/data/backups",
+		},
+		// Creating a new base object.
+		config.SubConfig{
+			Type:  "mariadb",
+			Name:  "mariadb1",
+			Viper: viper,
+		},
+	)
+
+	db := &MariaDB{
+		Base: base,
+	}
+
+	err := db.init()
+	assert.NoError(t, err)
+	script := db.build()
+	assert.Equal(t, script, "mariadb-backup --backup --host 1.2.3.4 --port 1234 -u user1 -ppass1 --databases-file=/data/backups/mariadb/mariadb1/databases-file.txt --a1 --a2 --a3 --target-dir=/data/backups/mariadb/mariadb1")
+}
+
+func TestMariaDB_dumpArgsWithAdditionalOptions(t *testing.T) {
+	base := newBase(
+		config.ModelConfig{
+			DumpPath: "/data/backups/",
+		},
+		config.SubConfig{
+			Type: "mariadb",
+			Name: "mariadb1",
+		},
+	)
+	db := &MariaDB{
+		Base:     base,
+		host:     "127.0.0.2",
+		port:     "6378",
+		password: "*&^92'",
+		args:     "--datadir=/var/lib64/mysql",
+	}
+
+	assert.Equal(t, db.build(), "mariadb-backup --backup --host 127.0.0.2 --port 6378 -p*&^92' --datadir=/var/lib64/mysql --target-dir=/data/backups/mariadb/mariadb1")
+}
+
+func TestMariaDB_databasesfileContent(t *testing.T) {
+	base := newBase(
+		config.ModelConfig{
+			DumpPath: "/data/backups/",
+		},
+		config.SubConfig{
+			Type: "mariadb",
+			Name: "mariadb1",
+		},
+	)
+	db := &MariaDB{
+		Base:     base,
+		databases: []string{"foo", "bar"},
+	}
+	databasesfile := path.Join(db.dumpPath, "databases-file.txt")
+	content, err := ioutil.ReadFile(databasesfile)
+	assert.NoError(t, err)
+
+	fileContent := string(content)
+	actualList := strings.Split(strings.TrimSpace(fileContent), "\n")
+	assert.Equal(t, len(db.databases), len(actualList))
+	assert.Equal(t, db.databases, actualList)
+}


### PR DESCRIPTION
Add mariadb backup module using https://mariadb.com/kb/en/mariabackup/ 
Mariabackup is an open source tool provided by MariaDB for performing physical online backups of InnoDB and MyISAM tables. 

mariadb-backup should be installed with same or newer version than mariadb instance. 

type: mariadb

`host` - MariaDB server host, default: localhost
`port` - MariaDB server port, default: 3306
`socket` - MariaDB server, if use socket, for example: `/var/run/mysqld/mysqld.sock`, default: ``
`database` - database to backup, in format database[.table], default: all
`username` - default: root
`password`
`args` - Additional options for mariadb-backup utility, for example: `--datadir=/var/lib64/mysql`

Gobackup should have access to mysql files. If using docker deployment, you need to mount the datadir directory in the same place, default `/var/lib/mysql`

Example:
```
models:
  test_maria:
    databases:
      test_maria:
        type: mariadb
        host: localhost
        port: 3306
        database: database1
        username: root
        password: root
```