### PR TITLE
feat: add support for healthchecks.io notifications

### DIFF
--- a/notifier/base.go
+++ b/notifier/base.go
@@ -62,6 +62,8 @@ func newNotifier(name string, config config.SubConfig) (Notifier, *Base, error) 
 		return NewSES(base), base, nil
 	case "resend":
 		return NewResend(base), base, nil
+	case "healthchecks":
+		return NewHealthchecks(base), base, nil
 	}
 
 	return nil, nil, fmt.Errorf("Notifier: %s is not supported", name)

--- a/notifier/healthchecks.go
+++ b/notifier/healthchecks.go
@@ -1,0 +1,100 @@
+package notifier
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/gobackup/gobackup/logger"
+	"io"
+	"net/http"
+	"strings"
+)
+
+type Healthchecks struct {
+	Base
+	Service         string
+	successEndpoint string
+	failureEndpoint string
+	checkResult     func(status int, responseBody []byte) error
+}
+
+// NewHealthchecks
+// type: healthchecks
+// url: https://healthchecks.io/ping/e9ef3495-aa2b-4e8b-8927-a7138dd6c04c
+func NewHealthchecks(base *Base) *Healthchecks {
+	url := base.viper.GetString("url")
+
+	return &Healthchecks{
+		Base:            *base,
+		Service:         "Healthchecks",
+		successEndpoint: url,
+		failureEndpoint: url + "/fail",
+		checkResult: func(status int, responseBody []byte) error {
+			if status == 200 {
+				return nil
+			}
+
+			return fmt.Errorf("status: %d, body: %s", status, string(responseBody))
+		},
+	}
+}
+
+func (s *Healthchecks) getLogger() logger.Logger {
+	return logger.Tag(fmt.Sprintf("Notifier: %s", s.Service))
+}
+
+func (s *Healthchecks) notify(title string, message string) error {
+	logger := s.getLogger()
+	url := s.failureEndpoint
+	if strings.Contains(title, "OK") {
+		url = s.successEndpoint
+	}
+
+	payload, err := json.Marshal(map[string]string{
+		"title":   title,
+		"message": message,
+	})
+
+	logger.Infof("Send notification to %s...", url)
+	req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(string(payload)))
+	if err != nil {
+		logger.Error(err)
+		return err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		logger.Error(err)
+		return err
+	}
+	defer func(Body io.ReadCloser) {
+		err = Body.Close()
+		if err != nil {
+			logger.Error(err)
+		}
+	}(resp.Body)
+
+	var body []byte
+	if resp.Body != nil {
+		body, err = io.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+	}
+
+	if s.checkResult != nil {
+		err = s.checkResult(resp.StatusCode, body)
+		if err != nil {
+			logger.Error(err)
+			return nil
+		}
+	} else {
+		logger.Infof("Response body: %s", string(body))
+	}
+
+	logger.Info("Notification sent.")
+
+	return nil
+}

--- a/notifier/healthchecks_test.go
+++ b/notifier/healthchecks_test.go
@@ -1,0 +1,24 @@
+package notifier
+
+import (
+	"testing"
+
+	"github.com/longbridgeapp/assert"
+	"github.com/spf13/viper"
+)
+
+func Test_Healthchecks(t *testing.T) {
+	base := &Base{
+		viper: viper.New(),
+	}
+
+	s := NewHealthchecks(base)
+	assert.Equal(t, "Healthchecks", s.Service)
+
+	err := s.checkResult(200, []byte(`{"status":"ok"}`))
+	assert.NoError(t, err)
+
+	respBody := `{"status":"error"}`
+	err = s.checkResult(403, []byte(respBody))
+	assert.EqualError(t, err, "status: 403, body: "+respBody)
+}


### PR DESCRIPTION
Added support for [healthchecks.io](https://healthchecks.io/) notification. This should reduce number of notifications on a huge systems with `on_success` notifications enabled.