### PR TITLE
fix: backup fails when scp storage and split features are used together

### DIFF
--- a/storage/scp.go
+++ b/storage/scp.go
@@ -123,14 +123,6 @@ func (s *SCP) upload(fileKey string) error {
 		// directory
 		// 2022.12.04.07.09.47/2022.12.04.07.09.47.tar.xz-000
 		fileKeys = s.fileKeys
-
-		remotePath := filepath.Join(s.path, fileKey)
-		remoteDir := filepath.Dir(remotePath)
-
-		// mkdir
-		if err := s.run(fmt.Sprintf("mkdir -p %s", remoteDir)); err != nil {
-			return err
-		}
 	} else {
 		// file
 		// 2022.12.04.07.09.25.tar.xz
@@ -141,6 +133,12 @@ func (s *SCP) upload(fileKey string) error {
 		sourcePath := filepath.Join(filepath.Dir(s.archivePath), key)
 		remotePath := filepath.Join(s.path, key)
 
+		// mkdir
+		if err := s.run(fmt.Sprintf("mkdir -p %s", filepath.Dir(remotePath))); err != nil {
+			return err
+		}
+
+		// upload file
 		if err := s.up(sourcePath, remotePath); err != nil {
 			return err
 		}


### PR DESCRIPTION
scp storage does not create remote directories correctly when used with the split feature

before fix:
2024/05/24 15:40:20 [Splitter] Split to chunks
2024/05/24 15:40:20 [Splitter] Split done
2024/05/24 15:40:20 [Storage] => Storage | scp
scp upload fileKey: 2024.05.24.15.40.20
s.fileKeys: [2024.05.24.15.40.20/2024.05.24.15.40.20.tar.xz-aaa]
scp upload remotePath: /media/nas-0/gobackup/data/backups/gitea/2024.05.24.15.40.20
scp upload remoteDir: /media/nas-0/gobackup/data/backups/gitea
scp upload fileKeys: [2024.05.24.15.40.20/2024.05.24.15.40.20.tar.xz-aaa]
2024/05/24 15:40:23 [SCP] -> Uploading (2.6 kB)...
2024/05/24 15:40:23 [SCP] [========================================================] 100.00% (? p/s)
2024/05/24 15:40:23 [Model] Cleanup temp: /tmp/gobackup3184434374/
2024/05/24 15:40:23 [Model] Executing after_script...
"stop gitea backup" 
2024/05/24 15:40:23 [Model] store /media/nas-0/gobackup/data/backups/gitea/2024.05.24.15.40.20/2024.05.24.15.40.20.tar.xz-aaa failed: scp: /media/nas-0/gobackup/data/backups/gitea/2024.05.24.15.40.20/2024.05.24.15.40.20.tar.xz-aaa: No such file or directory

2024/05/24 15:40:23 [Notifier] Running 1 Notifiers
2024/05/24 15:40:23 [Notifier: Feishu] Send notification to https://open.feishu.cn/open-apis/bot/v2/hook/fb41f973-ce87-483a-b194-49f58a252971...
2024/05/24 15:40:25 [Notifier: Feishu] Notification sent.
2024/05/24 15:40:25 [Model gitea] store /media/nas-0/gobackup/data/backups/gitea/2024.05.24.15.40.20/2024.05.24.15.40.20.tar.xz-aaa failed: scp: /media/nas-0/gobackup/data/backups/gitea/2024.05.24.15.40.20/2024.05.24.15.40.20.tar.xz-aaa: No such file or directory



after fix:
2024/05/24 15:47:02 [Model: gitea] WorkDir: /tmp/gobackup4192690035/1716536822701328081/gitea
2024/05/24 15:47:02 [Archive] => includes 1 rules
2024/05/24 15:47:02 [Compressor] => Compress | txz
2024/05/24 15:47:02 [Compressor] -> /tmp/gobackup4192690035/1716536822701328081/2024.05.24.15.47.02.tar.xz
2024/05/24 15:47:02 [Splitter] Split to chunks
2024/05/24 15:47:02 [Splitter] Split done
2024/05/24 15:47:02 [Storage] => Storage | scp
2024/05/24 15:47:05 [SCP] -> Uploading (2.6 kB)...
2024/05/24 15:47:05 [SCP] [========================================================] 100.00% (? p/s)
2024/05/24 15:47:05 [SCP] Uploaded: /media/nas-0/gobackup/data/backups/gitea/2024.05.24.15.47.02/2024.05.24.15.47.02.tar.xz-aaa (Duration 42 milliseconds 282 microseconds)
2024/05/24 15:47:05 [SCP] Store succeeded
2024/05/24 15:47:05 [Model] Cleanup temp: /tmp/gobackup4192690035/
2024/05/24 15:47:05 [Model] Executing after_script...