### PR TITLE
Fixing Splitter binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN apk add \
   gzip \
   pigz \
   bzip2 \
+  coreutils \
   # there is no pbzip2 yet
   lzip \
   xz-dev \
@@ -41,7 +42,7 @@ RUN wget https://aka.ms/sqlpackage-linux && \
 ENV PATH="${PATH}:/opt/sqlpackage"
 
 # Install the influx CLI
-ARG INFLUX_CLI_VERSION=2.7.3
+ARG INFLUX_CLI_VERSION=2.7.5
 RUN case "$(uname -m)" in \
       x86_64) arch=amd64 ;; \
       aarch64) arch=arm64 ;; \


### PR DESCRIPTION
Fixing splitter binary by adding coreutils to docker image. It installs the whole coreutils package which consists of: https://pkgs.alpinelinux.org/contents?file=&path=&name=coreutils&branch=edge&repo=main&arch=x86_64

It should update the split binary to latest gnu version to avoid errors like this:

```
/usr/bin/split: unrecognized option: numeric-suffixes
BusyBox v1.36.1 (2023-11-07 18:53:09 UTC) multi-call binary.

Usage: split [OPTIONS] [INPUT [PREFIX]]

    -b N[k|m]    Split by N (kilo|mega)bytes
    -l N        Split by N lines
    -a N        Use N letters as suffix
```