### PR TITLE
Add "args" parameter to redis database

### DIFF
--- a/database/redis.go
+++ b/database/redis.go
@@ -37,6 +37,7 @@ type Redis struct {
 	invokeSave bool
 	// path of rdb file, example: /var/lib/redis/dump.rdb
 	rdbPath string
+	args    string
 
 	_dumpFilePath string
 }
@@ -56,6 +57,7 @@ func (db *Redis) init() (err error) {
 	db.password = viper.GetString("password")
 	db.rdbPath = viper.GetString("rdb_path")
 	db.invokeSave = viper.GetBool("invoke_save")
+	db.args = viper.GetString("args")
 
 	// Force set invokeSave = false, when mode = copy
 	if viper.GetString("mode") == "copy" {
@@ -101,6 +103,10 @@ func (db *Redis) build() string {
 	}
 	if len(db.password) > 0 {
 		args = append(args, `-a `+db.password)
+	}
+
+	if len(db.args) > 0 {
+		args = append(args, db.args)
 	}
 
 	args = append(args, "--rdb", db._dumpFilePath)

--- a/database/redis_test.go
+++ b/database/redis_test.go
@@ -52,6 +52,7 @@ func TestRedis_init_for_sync(t *testing.T) {
 	viper.Set("username", "user1")
 	viper.Set("password", "pass1")
 	viper.Set("invoke_save", "true")
+	viper.Set("args", "--tls --cacert redis_ca.pem")
 
 	base := newBase(
 		config.ModelConfig{
@@ -72,5 +73,5 @@ func TestRedis_init_for_sync(t *testing.T) {
 	err := db.init()
 	assert.NoError(t, err)
 
-	assert.Equal(t, db.build(), "redis-cli -h 1.2.3.4 -p 1234 -a pass1 --rdb /data/backups/redis/redis1/dump.rdb")
+	assert.Equal(t, db.build(), "redis-cli -h 1.2.3.4 -p 1234 -a pass1 --tls --cacert redis_ca.pem --rdb /data/backups/redis/redis1/dump.rdb")
 }


### PR DESCRIPTION
Extra arguments can be useful to perform backup against Redis servers with TLS encryption enabled.

Example

```yaml
models:
  my_app:
    databases:
      my_app:
        type: redis
        mode: sync
        host: $REDIS_HOST
        port: $REDIS_PORT
        password: $REDIS_PASSWORD
        invoke_save: false
        args: --tls --cacert /run/secrets/ca_cert.pem
```
