### PR TITLE
Update telegram.go for support `message_thread_id` param

### DIFF
--- a/notifier/telegram.go
+++ b/notifier/telegram.go
@@ -33,7 +33,7 @@ func NewTelegram(base *Base) *Webhook {
 		},
 		buildBody: func(title, message string) ([]byte, error) {
 			chat_id := base.viper.GetString("chat_id")
-			message_thread_id = base.viper.GetString("message_thread_id")
+			message_thread_id := base.viper.GetString("message_thread_id")
 
 			payload := telegramPayload{
 				ChatID: chat_id,

--- a/notifier/telegram.go
+++ b/notifier/telegram.go
@@ -8,8 +8,9 @@ import (
 )
 
 type telegramPayload struct {
-	ChatID string `json:"chat_id"`
-	Text   string `json:"text"`
+	ChatID 		string `json:"chat_id"`
+	Text   		string `json:"text"`
+	MessageThreadId string `json:"message_thread_id"`
 }
 
 const DEFAULT_TELEGRAM_ENDPOINT = "api.telegram.org"

--- a/notifier/telegram.go
+++ b/notifier/telegram.go
@@ -33,10 +33,12 @@ func NewTelegram(base *Base) *Webhook {
 		},
 		buildBody: func(title, message string) ([]byte, error) {
 			chat_id := base.viper.GetString("chat_id")
+			message_thread_id = base.viper.GetString("message_thread_id")
 
 			payload := telegramPayload{
 				ChatID: chat_id,
 				Text:   fmt.Sprintf("%s\n\n%s", title, message),
+				MessageThreadId: message_thread_id,
 			}
 
 			return json.Marshal(payload)

--- a/notifier/telegram_test.go
+++ b/notifier/telegram_test.go
@@ -22,7 +22,7 @@ func Test_Telegram(t *testing.T) {
 
 	body, err := s.buildBody("This is title", "This is body")
 	assert.NoError(t, err)
-	assert.Equal(t, `{"chat_id":"@gobackuptest","text":"This is title\n\nThis is body"}`, string(body))
+	assert.Equal(t, `{"chat_id":"@gobackuptest","text":"This is title\n\nThis is body","message_thread_id":""}`, string(body))
 
 	url, err := s.buildWebhookURL("")
 	assert.NoError(t, err)


### PR DESCRIPTION
## Summary
I noticed that the current Telegram notifier does not support the `message_thread_id` parameter, which is necessary for sending messages to specific threads in a forum-style chat.

## What I did
I added support for the `message_thread_id` parameter to the notifier.

## Note
I'm relatively new to Golang, so I welcome feedback on both functionality and code style.