### PR TITLE
Add GoogleChat Notifier and fix email bug

### DIFF
--- a/notifier/googlechat.go
+++ b/notifier/googlechat.go
@@ -1,0 +1,133 @@
+package notifier
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/gobackup/gobackup/logger"
+)
+
+type GoogleChat struct {
+	Base
+
+	Service string
+
+	method             string
+	contentType        string
+	buildBody          func(title, message string) ([]byte, error)
+	buildGoogleChatURL func(url string) (string, error)
+	checkResult        func(status int, responseBody []byte) error
+	buildHeaders       func() map[string]string
+}
+
+type GoogleChatPayload struct {
+	Text string `json:"text"`
+}
+
+func NewGoogleChat(base *Base) *GoogleChat {
+	base.viper.SetDefault("method", "POST")
+
+	return &GoogleChat{
+		Base:        *base,
+		Service:     "GoogleChat",
+		method:      base.viper.GetString("method"),
+		contentType: "application/json",
+		buildBody: func(title, message string) ([]byte, error) {
+			return json.Marshal(GoogleChatPayload{
+				Text: title + "\r\n" + message,
+			})
+		},
+		buildHeaders: func() map[string]string {
+			headers := make(map[string]string)
+			for key, value := range base.viper.GetStringMapString("headers") {
+				headers[key] = value
+			}
+
+			return headers
+		},
+		checkResult: func(status int, responseBody []byte) error {
+			if status == 200 {
+				return nil
+			}
+
+			return fmt.Errorf("status: %d, body: %s", status, string(responseBody))
+		},
+	}
+}
+
+func (s *GoogleChat) getLogger() logger.Logger {
+	return logger.Tag(fmt.Sprintf("Notifier: %s", s.Service))
+}
+
+func (s *GoogleChat) GoogleChatURL() (string, error) {
+	url := s.viper.GetString("url")
+
+	if s.buildGoogleChatURL == nil {
+		return url, nil
+	}
+
+	return s.buildGoogleChatURL(url)
+}
+
+func (s *GoogleChat) notify(title string, message string) error {
+	logger := s.getLogger()
+
+	url, err := s.GoogleChatURL()
+	if err != nil {
+		return err
+	}
+
+	payload, err := s.buildBody(title, message)
+	if err != nil {
+		return err
+	}
+
+	logger.Infof("Send notification to %s...", url)
+	req, err := http.NewRequest(s.method, url, strings.NewReader(string(payload)))
+	if err != nil {
+		logger.Error(err)
+		return err
+	}
+
+	req.Header.Set("Content-Type", s.contentType)
+
+	if s.buildHeaders != nil {
+		headers := s.buildHeaders()
+		for key, value := range headers {
+			req.Header.Set(key, value)
+		}
+	}
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		logger.Error(err)
+		return err
+	}
+	defer resp.Body.Close()
+
+	var body []byte
+	if resp.Body != nil {
+		body, err = io.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+	}
+
+	if s.checkResult != nil {
+		err = s.checkResult(resp.StatusCode, body)
+		if err != nil {
+			logger.Error(err)
+			return nil
+		}
+	} else {
+		logger.Infof("Response body: %s", string(body))
+	}
+
+	logger.Info("Notification sent.")
+
+	return nil
+}

--- a/notifier/mail.go
+++ b/notifier/mail.go
@@ -74,8 +74,12 @@ func (s Mail) buildBody(title string, message string) string {
 }
 
 func (s *Mail) notify(title string, message string) error {
-	auth := s.getAuth()
-
+	var auth smtp.Auth
+	if len(s.password) == 0 {
+		auth = nil
+	} else {
+		auth = s.getAuth()
+	}
 	// Connect to the server, authenticate, set the sender and recipient,
 	// and send the email all in one step.
 	to := s.to


### PR DESCRIPTION
1. Add GoogleChat Notifier Support
2. fix bug for email password is empy

1. 增加对GoogleChat Webhook的开箱即用的支持。（已测试）
2. 修复或者增强email通知，email 密码可以为空，来适用企业服务器的SMTP服务器密码时空的，采用IP白名单认证的。（已测试）

很好的项目，一直在用，希望作者可以合并代码，谢谢！