### PR TITLE
notifier: Fix GoogleChat read config not enable.

### DIFF
--- a/notifier/base.go
+++ b/notifier/base.go
@@ -64,7 +64,6 @@ func newNotifier(name string, config config.SubConfig) (Notifier, *Base, error) 
 		return NewResend(base), base, nil
 	case "wxwork":
 		return NewWxWork(base), base, nil
-	}
 	case "googlechat":
 	        return NewGoogleChat(base), base, nil
  	}

--- a/notifier/base.go
+++ b/notifier/base.go
@@ -65,6 +65,9 @@ func newNotifier(name string, config config.SubConfig) (Notifier, *Base, error) 
 	case "wxwork":
 		return NewWxWork(base), base, nil
 	}
+	case "googlechat":
+	        return NewGoogleChat(base), base, nil
+ 	}
 
 	return nil, nil, fmt.Errorf("Notifier: %s is not supported", name)
 }


### PR DESCRIPTION
Sorry, I forgot to submit the changes to notifier/base.go to add Google Chat.

Here's an example Google Chat notifier configuration.

    notifiers:
      googlechat:
        type: googlechat
        url: https://chat.googleapis.com/v1/spaces/XXXXX/messages?key=XXXXXX
        method: POST