### PR TITLE
shellcheck and shfmt on install script

### DIFF
--- a/install
+++ b/install
@@ -2,21 +2,24 @@
 
 set -u
 
-type curl > /dev/null || { echo "curl: not found"; exit 1; }
+type curl >/dev/null || {
+  echo "curl: not found"
+  exit 1
+}
 
 set -e
 
 get_latest_release() {
-  local repo="$1"
-	curl -sSL "https://api.github.com/repos/${repo}/releases/latest" | \
+  repo="$1"
+  curl -sSL "https://api.github.com/repos/${repo}/releases/latest" |
     awk 'BEGIN{FS=": |,|\""}; /tag_name/{print $5}'
 }
 
 repo="gobackup/gobackup"
-version="$(get_latest_release "${repo}")"  # v1.2.0
+version="$(get_latest_release "${repo}")" # v1.2.0
 
 # if args has version override it and not eq "latest"
-if test $# -eq 1; then
+if test "$#" -eq 1; then
   if test "$1" != "latest"; then
     version="$1"
 
@@ -24,7 +27,7 @@ if test $# -eq 1; then
   fi
 fi
 
-platform="$(uname | tr "[A-Z]" "[a-z]")"  # Linux => linux
+platform="$(uname | tr "[:upper:]" "[:lower:]")"                    # Linux => linux
 arch="$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')" # x86_64 => amd64, aarch64 => arm64
 package="gobackup-${platform}-${arch}.tar.gz"
 package_url="https://github.com/${repo}/releases/download/${version}/${package}"
@@ -33,6 +36,7 @@ dest_dir="/usr/local/bin"
 bin_path="${dest_dir}/${bin}"
 tmp_dir="$(mktemp -d)"
 
+# shellcheck disable=SC2064
 trap "rm -r ${tmp_dir}" EXIT
 
 if test -e "${bin_path}"; then
@@ -47,7 +51,7 @@ fi
 cd "${tmp_dir}"
 curl -sSL "${package_url}" | tar xzf -
 
-if test $(id -u) -eq 0; then
+if test "$(id -u)" -eq 0; then
   mv "${bin}" "${dest_dir}"
 else
   sudo mv "${bin}" "${dest_dir}"


### PR DESCRIPTION
While trying to use the project's install script, I noticed that the install script could use some optimization, so I formatted the script with [shfmt](https://github.com/mvdan/sh), as well as eliminating several warnings generated by [shellcheck](https://github.com/koalaman/shellcheck).

Here is the output of shellcheck on the install script before this commit,

```
$ shellcheck install

In install line 10:
  local repo="$1"
  ^--------^ SC3043 (warning): In POSIX sh, 'local' is undefined.


In install line 27:
platform="$(uname | tr "[A-Z]" "[a-z]")"  # Linux => linux
                       ^-----^ SC2021 (info): Don't use [] around classes in tr, it replaces literal square brackets.
                               ^-----^ SC2021 (info): Don't use [] around classes in tr, it replaces literal square brackets.


In install line 36:
trap "rm -r ${tmp_dir}" EXIT
            ^--------^ SC2064 (warning): Use single quotes, otherwise this expands now rather than when signalled.


In install line 50:
if test $(id -u) -eq 0; then
        ^------^ SC2046 (warning): Quote this to prevent word splitting.

For more information:
  https://www.shellcheck.net/wiki/SC2046 -- Quote this to prevent word splitt...
  https://www.shellcheck.net/wiki/SC2064 -- Use single quotes, otherwise this...
  https://www.shellcheck.net/wiki/SC3043 -- In POSIX sh, 'local' is undefined.
```