### PR TITLE
fix: empty console output when log file creation failed

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -46,8 +46,13 @@ func init() {
 }
 
 func SetLogger(logPath string) {
-	logfile, _ := os.OpenFile(logPath, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
-	multi := io.MultiWriter(logfile, os.Stdout)
+	writers := make([]io.Writer, 0)
+	writers = append(writers, os.Stdout)
+	logfile, err := os.OpenFile(logPath, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
+	if err == nil {
+		writers = append(writers, logfile)
+	}
+	multi := io.MultiWriter(writers...)
 	_myLog = log.New(&writer{multi, TimeFormat}, "", 0)
 	sharedLogger = newLogger()
 }


### PR DESCRIPTION
When `os.OpenFile` fails, it returns an empty writer, which may prevent the logger from outputting logs normally.
