### PR TITLE
bug: fix unchecked error

### DIFF
--- a/notifier/healthchecks.go
+++ b/notifier/healthchecks.go
@@ -3,10 +3,11 @@ package notifier
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/gobackup/gobackup/logger"
 	"io"
 	"net/http"
 	"strings"
+
+	"github.com/gobackup/gobackup/logger"
 )
 
 type Healthchecks struct {
@@ -53,6 +54,10 @@ func (s *Healthchecks) notify(title string, message string) error {
 		"title":   title,
 		"message": message,
 	})
+	if err != nil {
+		logger.Error(err)
+		return err
+	}
 
 	logger.Infof("Send notification to %s...", url)
 	req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(string(payload)))

--- a/storage/base.go
+++ b/storage/base.go
@@ -203,7 +203,7 @@ func List(model config.ModelConfig, parent string) (items []FileItem, err error)
 
 		// Sort items by LastModified, Filename in descending
 		sort.Slice(items, func(i, j int) bool {
-			if items[i].LastModified == items[j].LastModified {
+			if items[i].LastModified.Equal(items[j].LastModified) {
 				return items[i].Filename > items[j].Filename
 			}
 			return items[i].LastModified.After(items[j].LastModified)


### PR DESCRIPTION
1. In healthchecks.go:
   - Added error handling for JSON serialization before sending notifications

2. In storage/base.go:
   - Changed from equality operator (`==`) to proper time comparison using `.Equal()` method