### PR TITLE
fix: Add fetchOptions to include credentials in App component

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -25,6 +25,7 @@ const LogView = () => {
             stream
             follow={follow}
             onScroll={onScroll}
+            fetchOptions={{ credentials: 'include' }}
           />
         )}
       />


### PR DESCRIPTION
Cookies for Authelia is on another origin, so the value should be `include` not `same-origin`.

Refer:
- https://mozilla-frontend-infra.github.io/react-lazylog/
- https://github.com/mozilla-frontend-infra/react-lazylog/blob/962d294b18dd657a0c84ab05062a6bd8339c8180/src/components/LazyLog/index.jsx#L53
- Code in ts: `type RequestCredentials = "include" | "omit" | "same-origin";`

resolve #325 