### PR TITLE
Support `compress_with` with empty to disable compression

### DIFF
--- a/compressor/base.go
+++ b/compressor/base.go
@@ -44,15 +44,17 @@ func newBase(model config.ModelConfig) (base Base) {
 func Run(model config.ModelConfig) (string, error) {
 	logger := logger.Tag("Compressor")
 
+	// Skip compression if type is not set
+	if model.CompressWith.Type == "" {
+		logger.Info("=> Compress | skipped (no compression type specified)")
+		return model.DumpPath, nil
+	}
+
 	base := newBase(model)
 
 	var c Compressor
 	var ext, parallelProgram string
 	switch model.CompressWith.Type {
-	case "none":
-		// Skip compression, return dump path directly
-		logger.Info("=> Compress | none (skipped)")
-		return model.DumpPath, nil
 	case "gz", "tgz", "taz", "tar.gz":
 		ext = ".tar.gz"
 		parallelProgram = "pigz"
@@ -74,9 +76,6 @@ func Run(model config.ModelConfig) (string, error) {
 		ext = ".tar.zst"
 	case "tar":
 		ext = ".tar"
-	case "":
-		ext = ".tar"
-		model.CompressWith.Type = "tar"
 	default:
 		return "", fmt.Errorf("Unsupported compress type: %s", model.CompressWith.Type)
 	}

--- a/compressor/base_test.go
+++ b/compressor/base_test.go
@@ -50,15 +50,15 @@ func TestBaseInterface(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-func TestRun_NoneType(t *testing.T) {
+func TestRun_EmptyType(t *testing.T) {
 	v := viper.New()
 	v.SetDefault("filename_format", "2006.01.02.15.04.05")
 
 	model := config.ModelConfig{
-		Name:     "TestNone",
+		Name:     "TestEmptyType",
 		DumpPath: "/tmp/test_dump",
 		CompressWith: config.SubConfig{
-			Type:  "none",
+			Type:  "",
 			Viper: v,
 		},
 		Viper: viper.New(),


### PR DESCRIPTION
## Summary
This PR fixes #353

## Changes
- `compressor/base.go`
- `compressor/base_test.go`
