### PR TITLE
Fix pid file are empty when running as a daemon

### DIFF
--- a/main.go
+++ b/main.go
@@ -94,7 +94,7 @@ func main() {
 			Action: func(ctx *cli.Context) error {
 				fmt.Println("GoBackup starting...")
 
-				args := []string{"gobackup", "run"}
+				args := []string{"gobackup", "start"}
 				if len(configFile) != 0 {
 					args = append(args, "--config", configFile)
 				}


### PR DESCRIPTION
Fixes #332

## Changes
- Change daemon child process args from `gobackup run` to `gobackup start`
- Ensures child process goes through proper daemon initialization and writes PID file correctly