### PR TITLE
Fix OpenSSL encryptor: args is treated as a single token

### DIFF
--- a/encryptor/openssl.go
+++ b/encryptor/openssl.go
@@ -66,7 +66,7 @@ func (enc *OpenSSL) options() (opts []string) {
 		opts = append(opts, "-salt")
 	}
 	if len(enc.args) > 0 {
-		opts = append(opts, enc.args)
+		opts = append(opts, strings.Fields(enc.args)...)
 	}
 
 	opts = append(opts, `-k`, enc.password)

--- a/encryptor/openssl_test.go
+++ b/encryptor/openssl_test.go
@@ -36,5 +36,8 @@ func TestOpenSSL_options(t *testing.T) {
 	assert.Equal(t, "gobackup-123", enc.password)
 	assert.Equal(t, "-pbkdf2 -iter 1000", enc.args)
 
-	assert.Equal(t, "rc4 -base64 -pbkdf2 -iter 1000 -k gobackup-123", strings.Join(enc.options(), " "))
+	opts := enc.options()
+	assert.Equal(t, "rc4 -base64 -pbkdf2 -iter 1000 -k gobackup-123", strings.Join(opts, " "))
+	// Verify args are properly split into separate tokens (not treated as single string)
+	assert.Equal(t, 7, len(opts)) // rc4, -base64, -pbkdf2, -iter, 1000, -k, gobackup-123
 }


### PR DESCRIPTION
Fixes #328

## Changes
- Use `strings.Fields()` to split args string into multiple CLI arguments
- Add test assertion to verify args are properly tokenized