### PR TITLE
Harden Telegram proxy handling

### DIFF
--- a/notifier/telegram.go
+++ b/notifier/telegram.go
@@ -21,6 +21,7 @@ func NewTelegram(base *Base) *Webhook {
 		Service:     "Telegram",
 		method:      "POST",
 		contentType: "application/json",
+		proxy:       base.viper.GetString("proxy"),
 		buildWebhookURL: func(url string) (string, error) {
 			token := base.viper.GetString("token")
 			endpoint := DEFAULT_TELEGRAM_ENDPOINT

--- a/notifier/telegram_test.go
+++ b/notifier/telegram_test.go
@@ -36,3 +36,30 @@ func Test_Telegram(t *testing.T) {
 	err = s.checkResult(403, []byte(respBody))
 	assert.EqualError(t, err, "status: 403, body: "+respBody)
 }
+
+func Test_TelegramWithProxy(t *testing.T) {
+	base := &Base{
+		viper: viper.New(),
+	}
+	base.viper.Set("token", "123213:this-is-my-token")
+	base.viper.Set("chat_id", "@gobackuptest")
+	base.viper.Set("proxy", "http://127.0.0.1:7890")
+
+	s := NewTelegram(base)
+
+	assert.Equal(t, "Telegram", s.Service)
+	assert.Equal(t, "http://127.0.0.1:7890", s.proxy)
+}
+
+func Test_TelegramWithoutProxy(t *testing.T) {
+	base := &Base{
+		viper: viper.New(),
+	}
+	base.viper.Set("token", "123213:this-is-my-token")
+	base.viper.Set("chat_id", "@gobackuptest")
+
+	s := NewTelegram(base)
+
+	assert.Equal(t, "Telegram", s.Service)
+	assert.Equal(t, "", s.proxy)
+}

--- a/notifier/webhook.go
+++ b/notifier/webhook.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	neturl "net/url"
 	"strings"
 
 	"github.com/gobackup/gobackup/logger"
@@ -17,6 +18,7 @@ type Webhook struct {
 
 	method          string
 	contentType     string
+	proxy           string
 	buildBody       func(title, message string) ([]byte, error)
 	buildWebhookURL func(url string) (string, error)
 	checkResult     func(status int, responseBody []byte) error
@@ -104,6 +106,24 @@ func (s *Webhook) notify(title string, message string) error {
 	}
 
 	client := &http.Client{}
+	if s.proxy != "" {
+		proxyValue := s.proxy
+		if !strings.Contains(proxyValue, "://") {
+			proxyValue = "http://" + proxyValue
+		}
+		proxyURL, err := neturl.Parse(proxyValue)
+		if err != nil {
+			logger.Errorf("Invalid proxy URL: %s", err)
+			return err
+		}
+		if transport, ok := http.DefaultTransport.(*http.Transport); ok {
+			clone := transport.Clone()
+			clone.Proxy = http.ProxyURL(proxyURL)
+			client.Transport = clone
+		} else {
+			client.Transport = &http.Transport{Proxy: http.ProxyURL(proxyURL)}
+		}
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		logger.Error(err)


### PR DESCRIPTION
## Summary
- keep default HTTP transport settings while applying proxy
- tolerate proxy values without scheme by adding http://
- set Telegram notifier proxy from config

## Testing
- go test ./notifier