### PR TITLE
Fix to avoid process exit status code : non zero exit on error

### DIFF
--- a/main.go
+++ b/main.go
@@ -178,11 +178,14 @@ func perform(modelNames []string) error {
 		}
 	}
 
+	var last_error error
+	last_error = nil
 	for _, m := range models {
 		if err := m.Perform(); err != nil {
 			logger.Tag(fmt.Sprintf("Model %s", m.Config.Name)).Error(err)
+			last_error = err
 		}
 	}
 
-	return nil
+	return last_error
 }


### PR DESCRIPTION
Process exit status code : when at least one model fails to backup, do not exit with status code 0 (meaning no error in Linux). This allows, for instance, a nice systemd-timer integration.
