### PR TITLE
refactor: introduce registry pattern for database, storage, and notifier

### DIFF
--- a/database/etcd.go
+++ b/database/etcd.go
@@ -9,6 +9,12 @@ import (
 	"github.com/gobackup/gobackup/logger"
 )
 
+func init() {
+	Register("etcd", func(base Base) Database {
+		return &Etcd{Base: base}
+	})
+}
+
 // etcd database
 //
 // ref:

--- a/database/firebird.go
+++ b/database/firebird.go
@@ -9,6 +9,12 @@ import (
 	"github.com/gobackup/gobackup/logger"
 )
 
+func init() {
+	Register("firebird", func(base Base) Database {
+		return &Firebird{Base: base}
+	})
+}
+
 // Firebird database
 //
 // With gbak utility : https://www.firebirdsql.org/file/documentation/html/en/firebirddocs/gbak/firebird-gbak.html

--- a/database/influxdb2.go
+++ b/database/influxdb2.go
@@ -7,6 +7,12 @@ import (
 	"github.com/gobackup/gobackup/logger"
 )
 
+func init() {
+	Register("influxdb2", func(base Base) Database {
+		return &InfluxDB2{Base: base}
+	})
+}
+
 // InfluxDB v2 database through `influx` cli
 // See https://docs.influxdata.com/influxdb/v2/reference/cli/influx/backup/
 type InfluxDB2 struct {

--- a/database/mariadb.go
+++ b/database/mariadb.go
@@ -8,6 +8,12 @@ import (
 	"github.com/gobackup/gobackup/logger"
 )
 
+func init() {
+	Register("mariadb", func(base Base) Database {
+		return &MariaDB{Base: base}
+	})
+}
+
 // Mariadb database
 //
 // type: mariadb

--- a/database/mongodb.go
+++ b/database/mongodb.go
@@ -8,6 +8,12 @@ import (
 	"github.com/gobackup/gobackup/logger"
 )
 
+func init() {
+	Register("mongodb", func(base Base) Database {
+		return &MongoDB{Base: base}
+	})
+}
+
 // MongoDB database
 //
 // type: mongodb

--- a/database/mssql.go
+++ b/database/mssql.go
@@ -8,6 +8,12 @@ import (
 	"github.com/gobackup/gobackup/logger"
 )
 
+func init() {
+	Register("mssql", func(base Base) Database {
+		return &MSSQL{Base: base}
+	})
+}
+
 // MSSQL database
 //
 // type: mssql

--- a/database/mysql.go
+++ b/database/mysql.go
@@ -9,6 +9,12 @@ import (
 	"github.com/gobackup/gobackup/logger"
 )
 
+func init() {
+	Register("mysql", func(base Base) Database {
+		return &MySQL{Base: base}
+	})
+}
+
 // MySQL database
 //
 // type: mysql

--- a/database/postgresql.go
+++ b/database/postgresql.go
@@ -11,6 +11,12 @@ import (
 	"github.com/gobackup/gobackup/logger"
 )
 
+func init() {
+	Register("postgresql", func(base Base) Database {
+		return &PostgreSQL{Base: base}
+	})
+}
+
 // PostgreSQL database
 //
 // ref:

--- a/database/redis.go
+++ b/database/redis.go
@@ -9,6 +9,12 @@ import (
 	"github.com/gobackup/gobackup/logger"
 )
 
+func init() {
+	Register("redis", func(base Base) Database {
+		return &Redis{Base: base}
+	})
+}
+
 type redisMode int
 
 const (

--- a/database/registry.go
+++ b/database/registry.go
@@ -1,0 +1,57 @@
+package database
+
+import (
+	"fmt"
+	"sync"
+)
+
+// Factory creates a Database instance from a Base configuration.
+// Each database type should register its factory using Register().
+type Factory func(base Base) Database
+
+var (
+	registry   = make(map[string]Factory)
+	registryMu sync.RWMutex
+)
+
+// Register adds a database factory to the registry.
+// This should be called in the init() function of each database type.
+// Example:
+//
+//	func init() {
+//	    Register("mysql", func(base Base) Database {
+//	        return &MySQL{Base: base}
+//	    })
+//	}
+func Register(name string, factory Factory) {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+
+	if factory == nil {
+		panic(fmt.Sprintf("database: Register factory is nil for %s", name))
+	}
+	if _, dup := registry[name]; dup {
+		panic(fmt.Sprintf("database: Register called twice for %s", name))
+	}
+	registry[name] = factory
+}
+
+// Get returns the factory for the given database type.
+// Returns nil if the type is not registered.
+func Get(name string) Factory {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+	return registry[name]
+}
+
+// ListTypes returns all registered database type names.
+func ListTypes() []string {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+
+	names := make([]string, 0, len(registry))
+	for name := range registry {
+		names = append(names, name)
+	}
+	return names
+}

--- a/database/sqlite.go
+++ b/database/sqlite.go
@@ -9,6 +9,12 @@ import (
 	"github.com/gobackup/gobackup/logger"
 )
 
+func init() {
+	Register("sqlite", func(base Base) Database {
+		return &SQLite{Base: base}
+	})
+}
+
 // SQLite database
 //
 // type: sqlite

--- a/notifier/dingtalk.go
+++ b/notifier/dingtalk.go
@@ -5,6 +5,12 @@ import (
 	"fmt"
 )
 
+func init() {
+	Register("dingtalk", func(base *Base) (Notifier, error) {
+		return NewDingtalk(base), nil
+	})
+}
+
 type dingtalkResult struct {
 	Code    int    `json:"errcode"`
 	Message string `json:"errmsg"`

--- a/notifier/discord.go
+++ b/notifier/discord.go
@@ -5,6 +5,12 @@ import (
 	"fmt"
 )
 
+func init() {
+	Register("discord", func(base *Base) (Notifier, error) {
+		return NewDiscord(base), nil
+	})
+}
+
 type discordPayload struct {
 	Content string `json:"content"`
 }

--- a/notifier/feisu.go
+++ b/notifier/feisu.go
@@ -5,6 +5,12 @@ import (
 	"fmt"
 )
 
+func init() {
+	Register("feishu", func(base *Base) (Notifier, error) {
+		return NewFeishu(base), nil
+	})
+}
+
 type feishuPayload struct {
 	MsgType string               `json:"msg_type"`
 	Content feishuPayloadContent `json:"content"`

--- a/notifier/github.go
+++ b/notifier/github.go
@@ -6,6 +6,12 @@ import (
 	"regexp"
 )
 
+func init() {
+	Register("github", func(base *Base) (Notifier, error) {
+		return NewGitHub(base), nil
+	})
+}
+
 type githubCommentPayload struct {
 	Body string `json:"body"`
 }

--- a/notifier/googlechat.go
+++ b/notifier/googlechat.go
@@ -10,6 +10,12 @@ import (
 	"github.com/gobackup/gobackup/logger"
 )
 
+func init() {
+	Register("googlechat", func(base *Base) (Notifier, error) {
+		return NewGoogleChat(base), nil
+	})
+}
+
 type GoogleChat struct {
 	Base
 

--- a/notifier/healthchecks.go
+++ b/notifier/healthchecks.go
@@ -10,6 +10,12 @@ import (
 	"github.com/gobackup/gobackup/logger"
 )
 
+func init() {
+	Register("healthchecks", func(base *Base) (Notifier, error) {
+		return NewHealthchecks(base), nil
+	})
+}
+
 type Healthchecks struct {
 	Base
 	Service         string

--- a/notifier/mail.go
+++ b/notifier/mail.go
@@ -10,6 +10,12 @@ import (
 	"strings"
 )
 
+func init() {
+	Register("mail", func(base *Base) (Notifier, error) {
+		return NewMail(base)
+	})
+}
+
 type Mail struct {
 	// Base is the base notifier
 	from     string

--- a/notifier/postmark.go
+++ b/notifier/postmark.go
@@ -5,6 +5,12 @@ import (
 	"fmt"
 )
 
+func init() {
+	Register("postmark", func(base *Base) (Notifier, error) {
+		return NewPostmark(base), nil
+	})
+}
+
 // postmarkPayload
 // https://postmarkapp.com/developer/user-guide/send-email-with-api
 type postmarkPayload struct {

--- a/notifier/registry.go
+++ b/notifier/registry.go
@@ -1,0 +1,57 @@
+package notifier
+
+import (
+	"fmt"
+	"sync"
+)
+
+// Factory creates a Notifier instance from a Base configuration.
+// Each notifier type should register its factory using Register().
+type Factory func(base *Base) (Notifier, error)
+
+var (
+	registry   = make(map[string]Factory)
+	registryMu sync.RWMutex
+)
+
+// Register adds a notifier factory to the registry.
+// This should be called in the init() function of each notifier type.
+// Example:
+//
+//	func init() {
+//	    Register("slack", func(base *Base) (Notifier, error) {
+//	        return NewSlack(base), nil
+//	    })
+//	}
+func Register(name string, factory Factory) {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+
+	if factory == nil {
+		panic(fmt.Sprintf("notifier: Register factory is nil for %s", name))
+	}
+	if _, dup := registry[name]; dup {
+		panic(fmt.Sprintf("notifier: Register called twice for %s", name))
+	}
+	registry[name] = factory
+}
+
+// Get returns the factory for the given notifier type.
+// Returns nil if the type is not registered.
+func Get(name string) Factory {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+	return registry[name]
+}
+
+// ListTypes returns all registered notifier type names.
+func ListTypes() []string {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+
+	names := make([]string, 0, len(registry))
+	for name := range registry {
+		names = append(names, name)
+	}
+	return names
+}

--- a/notifier/resend.go
+++ b/notifier/resend.go
@@ -5,6 +5,12 @@ import (
 	"fmt"
 )
 
+func init() {
+	Register("resend", func(base *Base) (Notifier, error) {
+		return NewResend(base), nil
+	})
+}
+
 // resendPayload
 // https://resend.com/docs/api-reference/emails/send-email
 type resendPayload struct {

--- a/notifier/sendgrid.go
+++ b/notifier/sendgrid.go
@@ -5,6 +5,12 @@ import (
 	"fmt"
 )
 
+func init() {
+	Register("sendgrid", func(base *Base) (Notifier, error) {
+		return NewSendGrid(base), nil
+	})
+}
+
 // sendgridPayload
 // https://docs.sendgrid.com/api-reference/mail-send/mail-send
 type sendgridPayload struct {

--- a/notifier/ses.go
+++ b/notifier/ses.go
@@ -8,6 +8,12 @@ import (
 	"github.com/gobackup/gobackup/logger"
 )
 
+func init() {
+	Register("ses", func(base *Base) (Notifier, error) {
+		return NewSES(base), nil
+	})
+}
+
 type SES struct {
 	Base
 	client *ses.SES

--- a/notifier/slack.go
+++ b/notifier/slack.go
@@ -5,6 +5,12 @@ import (
 	"fmt"
 )
 
+func init() {
+	Register("slack", func(base *Base) (Notifier, error) {
+		return NewSlack(base), nil
+	})
+}
+
 type slackPayload struct {
 	Text string `json:"text"`
 }

--- a/notifier/telegram.go
+++ b/notifier/telegram.go
@@ -7,6 +7,12 @@ import (
 	"github.com/gobackup/gobackup/helper"
 )
 
+func init() {
+	Register("telegram", func(base *Base) (Notifier, error) {
+		return NewTelegram(base), nil
+	})
+}
+
 type telegramPayload struct {
 	ChatID 		string `json:"chat_id"`
 	Text   		string `json:"text"`

--- a/notifier/webhook.go
+++ b/notifier/webhook.go
@@ -10,6 +10,12 @@ import (
 	"github.com/gobackup/gobackup/logger"
 )
 
+func init() {
+	Register("webhook", func(base *Base) (Notifier, error) {
+		return NewWebhook(base), nil
+	})
+}
+
 type Webhook struct {
 	Base
 

--- a/notifier/wxwork.go
+++ b/notifier/wxwork.go
@@ -5,6 +5,12 @@ import (
 	"fmt"
 )
 
+func init() {
+	Register("wxwork", func(base *Base) (Notifier, error) {
+		return NewWxWork(base), nil
+	})
+}
+
 type wxworkResult struct {
 	Code    int    `json:"errcode"`
 	Message string `json:"errmsg"`

--- a/storage/azure.go
+++ b/storage/azure.go
@@ -15,6 +15,12 @@ import (
 	"github.com/gobackup/gobackup/logger"
 )
 
+func init() {
+	Register("azure", func(base Base) Storage {
+		return &Azure{Base: base}
+	})
+}
+
 // Azure - Microsoft Azure Blob Storage
 //
 // type: azure

--- a/storage/base.go
+++ b/storage/base.go
@@ -86,53 +86,13 @@ func new(model config.ModelConfig, archivePath string, storageConfig config.SubC
 		panic(err)
 	}
 
-	var s Storage
-	switch storageConfig.Type {
-	case "local":
-		s = &Local{Base: base}
-	case "webdav":
-		s = &WebDAV{Base: base}
-	case "ftp":
-		s = &FTP{Base: base}
-	case "scp":
-		s = &SCP{Base: base}
-	case "sftp":
-		s = &SFTP{Base: base}
-	case "oss":
-		s = &S3{Base: base, Service: "oss"}
-	case "gcs":
-		s = &GCS{Base: base}
-	case "s3":
-		s = &S3{Base: base, Service: "s3"}
-	case "minio":
-		s = &S3{Base: base, Service: "minio"}
-	case "b2":
-		s = &S3{Base: base, Service: "b2"}
-	case "us3":
-		s = &S3{Base: base, Service: "us3"}
-	case "cos":
-		s = &S3{Base: base, Service: "cos"}
-	case "kodo":
-		s = &S3{Base: base, Service: "kodo"}
-	case "r2":
-		s = &S3{Base: base, Service: "r2"}
-	case "spaces":
-		s = &S3{Base: base, Service: "spaces"}
-	case "bos":
-		s = &S3{Base: base, Service: "bos"}
-	case "obs":
-		s = &S3{Base: base, Service: "obs"}
-	case "tos":
-		s = &S3{Base: base, Service: "tos"}
-	case "upyun":
-		s = &S3{Base: base, Service: "upyun"}
-	case "azure":
-		s = &Azure{Base: base}
-	default:
-		logger.Errorf("[%s] storage type has not implement.", storageConfig.Type)
+	factory := Get(storageConfig.Type)
+	if factory == nil {
+		logger.Errorf("[%s] storage type has not been implemented.", storageConfig.Type)
+		return base, nil
 	}
 
-	return base, s
+	return base, factory(base)
 }
 
 // run storage

--- a/storage/ftp.go
+++ b/storage/ftp.go
@@ -16,6 +16,12 @@ import (
 	"github.com/gobackup/gobackup/logger"
 )
 
+func init() {
+	Register("ftp", func(base Base) Storage {
+		return &FTP{Base: base}
+	})
+}
+
 // FTP storage
 //
 // type: ftp

--- a/storage/gcs.go
+++ b/storage/gcs.go
@@ -18,6 +18,12 @@ import (
 	"github.com/gobackup/gobackup/logger"
 )
 
+func init() {
+	Register("gcs", func(base Base) Storage {
+		return &GCS{Base: base}
+	})
+}
+
 // GCS - Google Clound storage
 //
 // type: gcs

--- a/storage/local.go
+++ b/storage/local.go
@@ -11,6 +11,12 @@ import (
 	"github.com/gobackup/gobackup/logger"
 )
 
+func init() {
+	Register("local", func(base Base) Storage {
+		return &Local{Base: base}
+	})
+}
+
 // Local storage
 //
 // type: local

--- a/storage/registry.go
+++ b/storage/registry.go
@@ -1,0 +1,57 @@
+package storage
+
+import (
+	"fmt"
+	"sync"
+)
+
+// Factory creates a Storage instance from a Base configuration.
+// Each storage type should register its factory using Register().
+type Factory func(base Base) Storage
+
+var (
+	registry   = make(map[string]Factory)
+	registryMu sync.RWMutex
+)
+
+// Register adds a storage factory to the registry.
+// This should be called in the init() function of each storage type.
+// Example:
+//
+//	func init() {
+//	    Register("s3", func(base Base) Storage {
+//	        return &S3{Base: base}
+//	    })
+//	}
+func Register(name string, factory Factory) {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+
+	if factory == nil {
+		panic(fmt.Sprintf("storage: Register factory is nil for %s", name))
+	}
+	if _, dup := registry[name]; dup {
+		panic(fmt.Sprintf("storage: Register called twice for %s", name))
+	}
+	registry[name] = factory
+}
+
+// Get returns the factory for the given storage type.
+// Returns nil if the type is not registered.
+func Get(name string) Factory {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+	return registry[name]
+}
+
+// ListTypes returns all registered storage type names.
+func ListTypes() []string {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+
+	names := make([]string, 0, len(registry))
+	for name := range registry {
+		names = append(names, name)
+	}
+	return names
+}

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -18,6 +18,20 @@ import (
 	"github.com/gobackup/gobackup/logger"
 )
 
+func init() {
+	// Register S3 and all S3-compatible services
+	s3Services := []string{
+		"s3", "oss", "minio", "b2", "us3", "cos",
+		"kodo", "r2", "spaces", "bos", "obs", "tos", "upyun",
+	}
+	for _, service := range s3Services {
+		svc := service // capture for closure
+		Register(svc, func(base Base) Storage {
+			return &S3{Base: base, Service: svc}
+		})
+	}
+}
+
 // S3 - Amazon S3 storage
 //
 // type: s3

--- a/storage/scp.go
+++ b/storage/scp.go
@@ -18,6 +18,12 @@ import (
 	"github.com/gobackup/gobackup/logger"
 )
 
+func init() {
+	Register("scp", func(base Base) Storage {
+		return &SCP{Base: base}
+	})
+}
+
 // SSH
 //
 // host:

--- a/storage/sftp.go
+++ b/storage/sftp.go
@@ -16,6 +16,12 @@ import (
 	"github.com/gobackup/gobackup/logger"
 )
 
+func init() {
+	Register("sftp", func(base Base) Storage {
+		return &SFTP{Base: base}
+	})
+}
+
 // SFTP storage
 //
 // type: sftp

--- a/storage/webdav.go
+++ b/storage/webdav.go
@@ -12,6 +12,12 @@ import (
 	"github.com/gobackup/gobackup/logger"
 )
 
+func init() {
+	Register("webdav", func(base Base) Storage {
+		return &WebDAV{Base: base}
+	})
+}
+
 // WebDAV storage
 //
 // # Install WebDAV Server on macOS


### PR DESCRIPTION
## Summary

This PR refactors the factory pattern used in database, storage, and notifier packages from switch-case to a registry-based approach.

## Changes

- Add `registry.go` for each package (database, storage, notifier)
- Each type now registers itself via `init()` function
- Remove large switch-case blocks from `base.go` files
- Maintain full backward compatibility

## Benefits

1. **Easier extensibility**: Adding new types only requires implementing the interface and calling `Register()`
2. **No central modifications**: No need to modify `base.go` when adding new types
3. **Better organization**: Each type is self-contained with its own registration
4. **Easier testing**: Can mock registry for unit tests

## Example

Before (in base.go):
```go
switch dbConfig.Type {
case "mysql":
    db = &MySQL{Base: base}
case "postgresql":
    db = &PostgreSQL{Base: base}
// ... 10+ more cases
}
```

After (in each type file):
```go
func init() {
    Register("mysql", func(base Base) Database {
        return &MySQL{Base: base}
    })
}
```

## Testing

- All existing tests pass
- Build succeeds
- No breaking changes