### PR TITLE
refactor: replace switch-case with explicit registry pattern

### DIFF
--- a/database/base.go
+++ b/database/base.go
@@ -58,37 +58,18 @@ func runHook(action, script string) error {
 	return nil
 }
 
-// New - initialize Database
+// runModel - initialize and run a Database backup
 func runModel(model config.ModelConfig, dbConfig config.SubConfig) (err error) {
 	logger := logger.Tag("Database")
 
 	base := newBase(model, dbConfig)
-	var db Database
-	switch dbConfig.Type {
-	case "mysql":
-		db = &MySQL{Base: base}
-	case "mariadb":
-		db = &MariaDB{Base: base}
-	case "redis":
-		db = &Redis{Base: base}
-	case "postgresql":
-		db = &PostgreSQL{Base: base}
-	case "mongodb":
-		db = &MongoDB{Base: base}
-	case "sqlite":
-		db = &SQLite{Base: base}
-	case "mssql":
-		db = &MSSQL{Base: base}
-	case "influxdb2":
-		db = &InfluxDB2{Base: base}
-	case "etcd":
-		db = &Etcd{Base: base}
-	case "firebird":
-		db = &Firebird{Base: base}
-	default:
-		logger.Warn(fmt.Errorf("model: %s databases.%s config `type: %s`, but is not implement", model.Name, dbConfig.Name, dbConfig.Type))
-		return
+
+	factory, err := DefaultRegistry.Get(dbConfig.Type)
+	if err != nil {
+		logger.Warn(fmt.Errorf("model: %s databases.%s config `type: %s`, but is not implemented", model.Name, dbConfig.Name, dbConfig.Type))
+		return nil
 	}
+	db := factory(base)
 
 	logger.Infof("=> database | %v: %v", dbConfig.Type, base.name)
 

--- a/database/register.go
+++ b/database/register.go
@@ -1,0 +1,65 @@
+package database
+
+// RegisterAll registers all built-in database types to the DefaultRegistry
+func RegisterAll() {
+	Register("mysql", NewMySQL)
+	Register("mariadb", NewMariaDB)
+	Register("redis", NewRedis)
+	Register("postgresql", NewPostgreSQL)
+	Register("mongodb", NewMongoDB)
+	Register("sqlite", NewSQLite)
+	Register("mssql", NewMSSQL)
+	Register("influxdb2", NewInfluxDB2)
+	Register("etcd", NewEtcd)
+	Register("firebird", NewFirebird)
+}
+
+// NewMySQL creates a new MySQL database handler
+func NewMySQL(base Base) Database {
+	return &MySQL{Base: base}
+}
+
+// NewMariaDB creates a new MariaDB database handler
+func NewMariaDB(base Base) Database {
+	return &MariaDB{Base: base}
+}
+
+// NewRedis creates a new Redis database handler
+func NewRedis(base Base) Database {
+	return &Redis{Base: base}
+}
+
+// NewPostgreSQL creates a new PostgreSQL database handler
+func NewPostgreSQL(base Base) Database {
+	return &PostgreSQL{Base: base}
+}
+
+// NewMongoDB creates a new MongoDB database handler
+func NewMongoDB(base Base) Database {
+	return &MongoDB{Base: base}
+}
+
+// NewSQLite creates a new SQLite database handler
+func NewSQLite(base Base) Database {
+	return &SQLite{Base: base}
+}
+
+// NewMSSQL creates a new MSSQL database handler
+func NewMSSQL(base Base) Database {
+	return &MSSQL{Base: base}
+}
+
+// NewInfluxDB2 creates a new InfluxDB2 database handler
+func NewInfluxDB2(base Base) Database {
+	return &InfluxDB2{Base: base}
+}
+
+// NewEtcd creates a new Etcd database handler
+func NewEtcd(base Base) Database {
+	return &Etcd{Base: base}
+}
+
+// NewFirebird creates a new Firebird database handler
+func NewFirebird(base Base) Database {
+	return &Firebird{Base: base}
+}

--- a/database/registry.go
+++ b/database/registry.go
@@ -1,0 +1,66 @@
+package database
+
+import (
+	"fmt"
+	"sync"
+)
+
+// Factory creates a Database instance from Base config
+type Factory func(base Base) Database
+
+// Registry holds all registered database factories
+type Registry struct {
+	mu        sync.RWMutex
+	factories map[string]Factory
+}
+
+// NewRegistry creates a new empty registry
+func NewRegistry() *Registry {
+	return &Registry{
+		factories: make(map[string]Factory),
+	}
+}
+
+// Register adds a factory for the given database type
+func (r *Registry) Register(name string, factory Factory) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.factories[name] = factory
+}
+
+// Get returns the factory for the given database type
+func (r *Registry) Get(name string) (Factory, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if factory, ok := r.factories[name]; ok {
+		return factory, nil
+	}
+	return nil, fmt.Errorf("unsupported database type: %s", name)
+}
+
+// Has checks if a database type is registered
+func (r *Registry) Has(name string) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	_, ok := r.factories[name]
+	return ok
+}
+
+// Types returns all registered database type names
+func (r *Registry) Types() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	types := make([]string, 0, len(r.factories))
+	for name := range r.factories {
+		types = append(types, name)
+	}
+	return types
+}
+
+// DefaultRegistry is the global registry used by Run()
+var DefaultRegistry = NewRegistry()
+
+// Register is a convenience function for DefaultRegistry.Register
+func Register(name string, factory Factory) {
+	DefaultRegistry.Register(name, factory)
+}

--- a/notifier/base.go
+++ b/notifier/base.go
@@ -36,41 +36,17 @@ func newNotifier(name string, config config.SubConfig) (Notifier, *Base, error) 
 	base.onSuccess = base.viper.GetBool("on_success")
 	base.onFailure = base.viper.GetBool("on_failure")
 
-	switch config.Type {
-	case "mail":
-		mail, err := NewMail(base)
-		return mail, base, err
-	case "webhook":
-		return NewWebhook(base), base, nil
-	case "feishu":
-		return NewFeishu(base), base, nil
-	case "dingtalk":
-		return NewDingtalk(base), base, nil
-	case "discord":
-		return NewDiscord(base), base, nil
-	case "slack":
-		return NewSlack(base), base, nil
-	case "github":
-		return NewGitHub(base), base, nil
-	case "telegram":
-		return NewTelegram(base), base, nil
-	case "postmark":
-		return NewPostmark(base), base, nil
-	case "sendgrid":
-		return NewSendGrid(base), base, nil
-	case "ses":
-		return NewSES(base), base, nil
-	case "resend":
-		return NewResend(base), base, nil
-	case "wxwork":
-		return NewWxWork(base), base, nil
-	case "googlechat":
-	        return NewGoogleChat(base), base, nil
-	case "healthchecks":
-		return NewHealthchecks(base), base, nil
+	factory, err := DefaultRegistry.Get(config.Type)
+	if err != nil {
+		return nil, nil, fmt.Errorf("Notifier: %s is not supported", config.Type)
 	}
 
-	return nil, nil, fmt.Errorf("Notifier: %s is not supported", name)
+	notifier, err := factory(base)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return notifier, base, nil
 }
 
 func notify(model config.ModelConfig, title, message string, notifyType int) {

--- a/notifier/register.go
+++ b/notifier/register.go
@@ -1,0 +1,47 @@
+package notifier
+
+// RegisterAll registers all built-in notifier types to the DefaultRegistry
+func RegisterAll() {
+	Register("mail", wrapMail)
+	Register("webhook", wrap(NewWebhook))
+	Register("feishu", wrap(NewFeishu))
+	Register("dingtalk", wrap(NewDingtalk))
+	Register("discord", wrap(NewDiscord))
+	Register("slack", wrap(NewSlack))
+	Register("github", wrap(NewGitHub))
+	Register("telegram", wrap(NewTelegram))
+	Register("postmark", wrap(NewPostmark))
+	Register("sendgrid", wrap(NewSendGrid))
+	Register("ses", wrapSES)
+	Register("resend", wrap(NewResend))
+	Register("wxwork", wrap(NewWxWork))
+	Register("googlechat", wrapGoogleChat)
+	Register("healthchecks", wrapHealthchecks)
+}
+
+// wrap converts a simple factory func to the Factory signature
+func wrap(fn func(*Base) *Webhook) Factory {
+	return func(base *Base) (Notifier, error) {
+		return fn(base), nil
+	}
+}
+
+// wrapMail handles NewMail which returns (Notifier, error)
+func wrapMail(base *Base) (Notifier, error) {
+	return NewMail(base)
+}
+
+// wrapSES wraps NewSES to match Factory signature
+func wrapSES(base *Base) (Notifier, error) {
+	return NewSES(base), nil
+}
+
+// wrapGoogleChat wraps NewGoogleChat to match Factory signature
+func wrapGoogleChat(base *Base) (Notifier, error) {
+	return NewGoogleChat(base), nil
+}
+
+// wrapHealthchecks wraps NewHealthchecks to match Factory signature
+func wrapHealthchecks(base *Base) (Notifier, error) {
+	return NewHealthchecks(base), nil
+}

--- a/notifier/registry.go
+++ b/notifier/registry.go
@@ -1,0 +1,67 @@
+package notifier
+
+import (
+	"fmt"
+	"sync"
+)
+
+// Factory creates a Notifier instance from Base config
+// Returns (Notifier, error) to support notifiers that may fail during initialization
+type Factory func(base *Base) (Notifier, error)
+
+// Registry holds all registered notifier factories
+type Registry struct {
+	mu        sync.RWMutex
+	factories map[string]Factory
+}
+
+// NewRegistry creates a new empty registry
+func NewRegistry() *Registry {
+	return &Registry{
+		factories: make(map[string]Factory),
+	}
+}
+
+// Register adds a factory for the given notifier type
+func (r *Registry) Register(name string, factory Factory) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.factories[name] = factory
+}
+
+// Get returns the factory for the given notifier type
+func (r *Registry) Get(name string) (Factory, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if factory, ok := r.factories[name]; ok {
+		return factory, nil
+	}
+	return nil, fmt.Errorf("unsupported notifier type: %s", name)
+}
+
+// Has checks if a notifier type is registered
+func (r *Registry) Has(name string) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	_, ok := r.factories[name]
+	return ok
+}
+
+// Types returns all registered notifier type names
+func (r *Registry) Types() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	types := make([]string, 0, len(r.factories))
+	for name := range r.factories {
+		types = append(types, name)
+	}
+	return types
+}
+
+// DefaultRegistry is the global registry used by Run()
+var DefaultRegistry = NewRegistry()
+
+// Register is a convenience function for DefaultRegistry.Register
+func Register(name string, factory Factory) {
+	DefaultRegistry.Register(name, factory)
+}

--- a/register.go
+++ b/register.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"github.com/gobackup/gobackup/database"
+	"github.com/gobackup/gobackup/notifier"
+	"github.com/gobackup/gobackup/storage"
+)
+
+func init() {
+	// Register all built-in database types
+	database.RegisterAll()
+
+	// Register all built-in storage types
+	storage.RegisterAll()
+
+	// Register all built-in notifier types
+	notifier.RegisterAll()
+}

--- a/storage/base.go
+++ b/storage/base.go
@@ -86,53 +86,13 @@ func new(model config.ModelConfig, archivePath string, storageConfig config.SubC
 		panic(err)
 	}
 
-	var s Storage
-	switch storageConfig.Type {
-	case "local":
-		s = &Local{Base: base}
-	case "webdav":
-		s = &WebDAV{Base: base}
-	case "ftp":
-		s = &FTP{Base: base}
-	case "scp":
-		s = &SCP{Base: base}
-	case "sftp":
-		s = &SFTP{Base: base}
-	case "oss":
-		s = &S3{Base: base, Service: "oss"}
-	case "gcs":
-		s = &GCS{Base: base}
-	case "s3":
-		s = &S3{Base: base, Service: "s3"}
-	case "minio":
-		s = &S3{Base: base, Service: "minio"}
-	case "b2":
-		s = &S3{Base: base, Service: "b2"}
-	case "us3":
-		s = &S3{Base: base, Service: "us3"}
-	case "cos":
-		s = &S3{Base: base, Service: "cos"}
-	case "kodo":
-		s = &S3{Base: base, Service: "kodo"}
-	case "r2":
-		s = &S3{Base: base, Service: "r2"}
-	case "spaces":
-		s = &S3{Base: base, Service: "spaces"}
-	case "bos":
-		s = &S3{Base: base, Service: "bos"}
-	case "obs":
-		s = &S3{Base: base, Service: "obs"}
-	case "tos":
-		s = &S3{Base: base, Service: "tos"}
-	case "upyun":
-		s = &S3{Base: base, Service: "upyun"}
-	case "azure":
-		s = &Azure{Base: base}
-	default:
-		logger.Errorf("[%s] storage type has not implement.", storageConfig.Type)
+	factory, err := DefaultRegistry.Get(storageConfig.Type)
+	if err != nil {
+		logger.Errorf("[%s] storage type has not been implemented.", storageConfig.Type)
+		return base, nil
 	}
 
-	return base, s
+	return base, factory(base)
 }
 
 // run storage

--- a/storage/register.go
+++ b/storage/register.go
@@ -1,0 +1,69 @@
+package storage
+
+// RegisterAll registers all built-in storage types to the DefaultRegistry
+func RegisterAll() {
+	Register("local", NewLocal)
+	Register("webdav", NewWebDAV)
+	Register("ftp", NewFTP)
+	Register("scp", NewSCP)
+	Register("sftp", NewSFTP)
+	Register("gcs", NewGCS)
+	Register("azure", NewAzure)
+
+	// S3-compatible storages
+	Register("s3", NewS3("s3"))
+	Register("oss", NewS3("oss"))
+	Register("minio", NewS3("minio"))
+	Register("b2", NewS3("b2"))
+	Register("us3", NewS3("us3"))
+	Register("cos", NewS3("cos"))
+	Register("kodo", NewS3("kodo"))
+	Register("r2", NewS3("r2"))
+	Register("spaces", NewS3("spaces"))
+	Register("bos", NewS3("bos"))
+	Register("obs", NewS3("obs"))
+	Register("tos", NewS3("tos"))
+	Register("upyun", NewS3("upyun"))
+}
+
+// NewLocal creates a new Local storage handler
+func NewLocal(base Base) Storage {
+	return &Local{Base: base}
+}
+
+// NewWebDAV creates a new WebDAV storage handler
+func NewWebDAV(base Base) Storage {
+	return &WebDAV{Base: base}
+}
+
+// NewFTP creates a new FTP storage handler
+func NewFTP(base Base) Storage {
+	return &FTP{Base: base}
+}
+
+// NewSCP creates a new SCP storage handler
+func NewSCP(base Base) Storage {
+	return &SCP{Base: base}
+}
+
+// NewSFTP creates a new SFTP storage handler
+func NewSFTP(base Base) Storage {
+	return &SFTP{Base: base}
+}
+
+// NewGCS creates a new GCS storage handler
+func NewGCS(base Base) Storage {
+	return &GCS{Base: base}
+}
+
+// NewAzure creates a new Azure storage handler
+func NewAzure(base Base) Storage {
+	return &Azure{Base: base}
+}
+
+// NewS3 returns a factory function for S3-compatible storage with the given service name
+func NewS3(service string) Factory {
+	return func(base Base) Storage {
+		return &S3{Base: base, Service: service}
+	}
+}

--- a/storage/registry.go
+++ b/storage/registry.go
@@ -1,0 +1,66 @@
+package storage
+
+import (
+	"fmt"
+	"sync"
+)
+
+// Factory creates a Storage instance from Base config
+type Factory func(base Base) Storage
+
+// Registry holds all registered storage factories
+type Registry struct {
+	mu        sync.RWMutex
+	factories map[string]Factory
+}
+
+// NewRegistry creates a new empty registry
+func NewRegistry() *Registry {
+	return &Registry{
+		factories: make(map[string]Factory),
+	}
+}
+
+// Register adds a factory for the given storage type
+func (r *Registry) Register(name string, factory Factory) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.factories[name] = factory
+}
+
+// Get returns the factory for the given storage type
+func (r *Registry) Get(name string) (Factory, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if factory, ok := r.factories[name]; ok {
+		return factory, nil
+	}
+	return nil, fmt.Errorf("unsupported storage type: %s", name)
+}
+
+// Has checks if a storage type is registered
+func (r *Registry) Has(name string) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	_, ok := r.factories[name]
+	return ok
+}
+
+// Types returns all registered storage type names
+func (r *Registry) Types() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	types := make([]string, 0, len(r.factories))
+	for name := range r.factories {
+		types = append(types, name)
+	}
+	return types
+}
+
+// DefaultRegistry is the global registry used by Run()
+var DefaultRegistry = NewRegistry()
+
+// Register is a convenience function for DefaultRegistry.Register
+func Register(name string, factory Factory) {
+	DefaultRegistry.Register(name, factory)
+}


### PR DESCRIPTION
## Summary

Replace hardcoded switch-case blocks with an explicit registry pattern for database, storage, and notifier packages.

## Changes

### New Files
- `database/registry.go` - Registry type with thread-safe factory registration
- `database/register.go` - RegisterAll() and New* factory functions
- `storage/registry.go` - Registry type for storage backends
- `storage/register.go` - RegisterAll() and New* factory functions  
- `notifier/registry.go` - Registry type for notifiers
- `notifier/register.go` - RegisterAll() and wrapper functions
- `register.go` - Main package init() calls all RegisterAll()

### Modified Files
- `database/base.go` - Use registry instead of switch-case
- `storage/base.go` - Use registry instead of switch-case
- `notifier/base.go` - Use registry instead of switch-case

## Benefits

1. **Explicit dependencies** - No init() magic in each implementation file
2. **Testable** - Can create isolated registries for unit testing
3. **Extensible** - External packages can register custom implementations
4. **IDE-friendly** - Can trace registration calls, better code navigation

## Testing

```
go build ./...  ✅
go test ./database/... ./storage/... ./notifier/...  ✅
```