### PR TITLE
Add a validation for checking fields emptiness including databases and storages in config file

### DIFF
--- a/gobackup_test.yml
+++ b/gobackup_test.yml
@@ -89,6 +89,9 @@ models:
         username: ubuntu
         password: password
         timeout: 300
+    archive:
+      includes:
+        - /etc/hosts
   test_model:
     compress_with:
       type: tgz


### PR DESCRIPTION
Fix nil Viper when loading models by validating is a map and guarding missing sub-sections (databases, storages, notifiers). This should fix the panic reported in #367 and returns a clear config error instead.

Failed Examples:

Example 1 - No Storage:
```
models:
  myjob:
    databases:
      postgres_all:
        host: localhost
        port: 5432
    storages: [Removed | Empty | null ]
```

Example 2 - No Database:
```
models:
  myjob:
    databases: [Removed | Empty | null ]
    storages:
      local:
        type: local
        keep: 2
```
