### PR TITLE
Fix cycler keep feature not working when storage path is configured

### DIFF
--- a/storage/base.go
+++ b/storage/base.go
@@ -36,6 +36,15 @@ type Storage interface {
 	upload(fileKey string) error
 	delete(fileKey string) error
 	list(parent string) ([]FileItem, error)
+	// download returns a URL for the given fileKey.
+	//
+	// NOTE: fileKey semantics differ from upload. upload() joins the storage
+	// `path` prefix internally, whereas download() expects fileKey to be the
+	// FULL remote path (already including the `path` prefix), matching the keys
+	// returned by list(). Callers that build a key from a relative name must
+	// prepend the storage `path` themselves — see Cycler.loadRemote. New
+	// implementations must NOT join `path` here, or such callers will
+	// double-prepend it and silently miss the object.
 	download(fileKey string) (string, error)
 }
 

--- a/storage/cycler.go
+++ b/storage/cycler.go
@@ -102,8 +102,21 @@ func (c *Cycler) loadRemote(storage Storage, cyclerFileName string, remoteStateK
 		return
 	}
 
+	// Prepend the storage path so the key matches what upload() writes.
+	// upload() does filepath.Join(s.path, fileKey) internally, but download()
+	// takes the full key as-is (it also serves the public Download API which
+	// already receives full paths from list()). Without this correction,
+	// loadRemote misses the file whenever s.path is non-empty and silently
+	// falls back to an empty local state, so keep never takes effect.
+	fullRemoteKey := remoteStateKey
+	if base := getBaseFromStorage(storage); base != nil && base.viper != nil {
+		if storagePath := base.viper.GetString("path"); storagePath != "" {
+			fullRemoteKey = filepath.Join(storagePath, remoteStateKey)
+		}
+	}
+
 	// Use download method to get a presigned URL
-	url, err := storage.download(remoteStateKey)
+	url, err := storage.download(fullRemoteKey)
 	if err == nil && url != "" {
 		// Fetch the data from the URL
 		resp, err := http.Get(url)
@@ -210,20 +223,22 @@ func (c *Cycler) saveRemote(storage Storage, cyclerFileName string, remoteStateK
 				base := getBaseFromStorage(storage)
 				if base != nil {
 					originalArchivePath := base.archivePath
-					// Set archivePath to a file in tmpDir so filepath.Dir(archivePath) = tmpDir
-					// This way filepath.Join(filepath.Dir(archivePath), remoteStateKey) = tmpFilePath
+					originalFileKeys := base.fileKeys
+					// Set archivePath so filepath.Dir(archivePath) = tmpDir, making
+					// upload read from tmpDir/remoteStateKey.
 					base.archivePath = filepath.Join(tmpDir, "dummy")
+					// Clear fileKeys so upload() uses the remoteStateKey argument
+					// directly instead of iterating over the original backup chunks.
+					base.fileKeys = nil
 
-					// Upload using remoteStateKey as the fileKey
-					// This will read from tmpDir/remoteStateKey and upload to s.path/remoteStateKey
 					if err := storage.upload(remoteStateKey); err != nil {
 						logger.Warnf("Failed to save cycler state to remote storage: %v", err)
 					} else {
 						logger.Info("Saved cycler state to remote storage")
 					}
 
-					// Restore original archivePath
 					base.archivePath = originalArchivePath
+					base.fileKeys = originalFileKeys
 				} else {
 					logger.Warn("Failed to get Base from storage for state upload")
 				}


### PR DESCRIPTION
## Problem

The `keep` retention feature stops working when the storage backend has a `path` configured (e.g. `path: backups` in S3/Spaces/GCS/Azure). After multiple backup jobs, the state file on remote storage only ever contains 1 entry, so old backups are never deleted.

## Root cause

Two bugs in the remote state persistence introduced in #354:

**Bug 1 — `loadRemote` reads from the wrong remote key**

`loadRemote` calls `storage.download(remoteStateKey)` where `remoteStateKey` is `.gobackup-state/<name>.json`. However, all `download()` implementations take the key **as-is** (they also serve the public `Download` API which already receives full paths from `list()`). Meanwhile `upload()` and `delete()` both prepend `s.path` internally via `filepath.Join(s.path, fileKey)`.

Result: with `path: backups`, the state is written to `backups/.gobackup-state/<name>.json` but read back from `.gobackup-state/<name>.json` — a 403/404 every time. `loadRemote` silently falls back to an empty local state, the cycler accumulates exactly 1 entry per run, and `keep` never fires.

**Bug 2 — `saveRemote` uploads wrong files for split/chunked backups**

`saveRemote` calls `storage.upload(remoteStateKey)` while `base.fileKeys` is still populated from the original backup. `upload()` checks `fileKeys` first and, when non-empty, iterates over those keys instead of the `fileKey` argument — so for chunked backups the state file is never uploaded to remote.

## Fix

- **`loadRemote`**: before calling `download()`, prepend `s.path` (read from viper via `getBaseFromStorage`) to build the full remote key — consistent with what `upload()` writes. No interface change needed.
- **`saveRemote`**: temporarily set `base.fileKeys = nil` around the `upload()` call (alongside the existing `archivePath` swap) and restore it afterward.

## Testing

Verified with DigitalOcean Spaces (`type: spaces`) with a non-empty `path`. After the fix, the state file correctly accumulates entries across runs and old backups are deleted once the `keep` limit is exceeded.